### PR TITLE
bump to 4.0.1, use Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: ruby
+cache: bundler
+sudo: false
+
+rvm:
+  - 2.1.10
+  - 2.2.5
+  - 2.3.1
+
+env:
+  - MAUTH_CONFIG_YML=`pwd`/spec/config_root/config/mauth.yml
+
+script: "bundle exec rspec"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # MAuth-Client History
 
-## v4.0.0
+## v4.0.1
 - Open source and publish this gem on rubygems.org, no functionality changes
+
+## v4.0.0
+- *yanked*
 
 ## v3.1.4
 - Use String#bytesize method instead of Rack::Utils' one, which was removed in Rack 2.0

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # MAuth Client
+[![Build Status](https://travis-ci.org/mdsol/mauth-client-ruby.svg)](https://travis-ci.org/mdsol/mauth-client-ruby)
 
 This gem consists of MAuth::Client, a class to manage the information needed to both sign and authenticate requests
 and responses, and middlewares for Rack and Faraday which leverage the client's capabilities.

--- a/lib/mauth/version.rb
+++ b/lib/mauth/version.rb
@@ -1,3 +1,3 @@
 module MAuth
-  VERSION = '4.0.0'.freeze
+  VERSION = '4.0.1'.freeze
 end

--- a/mauth-client.gemspec
+++ b/mauth-client.gemspec
@@ -6,10 +6,12 @@ Gem::Specification.new do |spec|
   spec.name          = 'mauth-client'
   spec.version       = MAuth::VERSION
   spec.authors       = ['Matthew Szenher', 'Aaron Suggs', 'Geoffrey Ducharme', 'Ethan']
-  spec.email         = ''
+  spec.email         = ['mszenher@mdsol.com']
   spec.summary       = 'Sign and authenticate requests and responses with mAuth authentication.'
-  spec.description   = 'Client for signing and authentication of requests and responses with mAuth authentication. Includes middleware for Rack and Faraday for incoding and outgoing requests and responses.'
-  spec.homepage      = 'https://github.com/mdsol/mauth-client'
+  spec.description   = 'Client for signing and authentication of requests and responses with mAuth authentication. Includes middleware for Rack and Faraday for incoming and outgoing requests and responses.'
+  spec.homepage      = 'https://github.com/mdsol/mauth-client-ruby'
+  spec.license       = 'MIT'
+  spec.required_ruby_version = '>= 2.1.0'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'


### PR DESCRIPTION
Trouble happened while publishing 4.0.0 on rubygems.org and since the same version cannot be re-upload we have to bump the version number.
Add the Travis CI config while we're at it.

@mdsol/team-10 