### PR TITLE
[MCC-197850] allow newer faradays

### DIFF
--- a/mauth-client.gemspec
+++ b/mauth-client.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '~> 0.7'
+  spec.add_dependency 'faraday', '>= 0.7.0', '< 1.0.0'
   spec.add_dependency 'faraday_middleware', '~> 0.9'
   spec.add_dependency 'term-ansicolor', '~> 1.0'
   spec.add_dependency 'coderay', '~> 1.0'


### PR DESCRIPTION
# Background 
~> 0.7 is getting quite old and many Medidata and open source gems are becoming dependent on newer versions; there's no reason to be so strict