### PR TITLE
[MCC-286290] Add # to signature escape 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # MAuth-Client History
 
+## v4.0.3
+- Updated signature to decode number sign (#) in requests
+
 ## v4.0.2
 - Store the config data to not load the config file multiple times
 

--- a/lib/mauth/client.rb
+++ b/lib/mauth/client.rb
@@ -365,7 +365,8 @@ module MAuth
 
         # do a moderately complex Euresource-style reencoding of the path
         object.attributes_for_signing[:request_url] = CGI.escape(original_request_uri.to_s)
-        object.attributes_for_signing[:request_url].gsub!('%2F', '/') # ...and then 'simply' decode the %2F's back into /'s, just like Euresource kind of does!
+        # decode forward slash and octothorpes back into characters like Euresource does
+        object.attributes_for_signing[:request_url].gsub!(/\w+/, '%2F' => '/', '%23' => '#')
         expected_euresource_style_reencoding = object.string_to_sign(time: object.x_mws_time, app_uuid: object.signature_app_uuid)
 
         # reset the object original request_uri, just in case we need it again

--- a/lib/mauth/client.rb
+++ b/lib/mauth/client.rb
@@ -365,7 +365,10 @@ module MAuth
 
         # do a moderately complex Euresource-style reencoding of the path
         object.attributes_for_signing[:request_url] = CGI.escape(original_request_uri.to_s)
-        # decode forward slash and octothorpes back into characters like Euresource does
+
+        # RFC 3986 (https://www.ietf.org/rfc/rfc3986.txt) reserves the forward slash "/"
+        #   and number sign "#" as component delimiters. Since these are valid URI components,
+        #   they are decoded back into characters here to avoid signature invalidation
         object.attributes_for_signing[:request_url].gsub!(/%2F|%23/, "%2F" => "/", "%23" => "#")
         expected_euresource_style_reencoding = object.string_to_sign(time: object.x_mws_time, app_uuid: object.signature_app_uuid)
 

--- a/lib/mauth/client.rb
+++ b/lib/mauth/client.rb
@@ -366,7 +366,7 @@ module MAuth
         # do a moderately complex Euresource-style reencoding of the path
         object.attributes_for_signing[:request_url] = CGI.escape(original_request_uri.to_s)
         # decode forward slash and octothorpes back into characters like Euresource does
-        object.attributes_for_signing[:request_url].gsub!(/\w+/, '%2F' => '/', '%23' => '#')
+        object.attributes_for_signing[:request_url].gsub!(/%2F|%23/, "%2F" => "/", "%23" => "#")
         expected_euresource_style_reencoding = object.string_to_sign(time: object.x_mws_time, app_uuid: object.signature_app_uuid)
 
         # reset the object original request_uri, just in case we need it again

--- a/lib/mauth/client.rb
+++ b/lib/mauth/client.rb
@@ -364,12 +364,7 @@ module MAuth
         expected_for_percent_reencoding = object.string_to_sign(time: object.x_mws_time, app_uuid: object.signature_app_uuid)
 
         # do a moderately complex Euresource-style reencoding of the path
-        object.attributes_for_signing[:request_url] = CGI.escape(original_request_uri.to_s)
-
-        # RFC 3986 (https://www.ietf.org/rfc/rfc3986.txt) reserves the forward slash "/"
-        #   and number sign "#" as component delimiters. Since these are valid URI components,
-        #   they are decoded back into characters here to avoid signature invalidation
-        object.attributes_for_signing[:request_url].gsub!(/%2F|%23/, "%2F" => "/", "%23" => "#")
+        object.attributes_for_signing[:request_url] = euresource_escape(original_request_uri.to_s)
         expected_euresource_style_reencoding = object.string_to_sign(time: object.x_mws_time, app_uuid: object.signature_app_uuid)
 
         # reset the object original request_uri, just in case we need it again
@@ -385,6 +380,13 @@ module MAuth
         unless expected_no_reencoding == actual || expected_euresource_style_reencoding == actual || expected_for_percent_reencoding == actual
           raise InauthenticError, "Signature verification failed for #{object.class}"
         end
+      end
+
+      # Note: RFC 3986 (https://www.ietf.org/rfc/rfc3986.txt) reserves the forward slash "/"
+      #   and number sign "#" as component delimiters. Since these are valid URI components,
+      #   they are decoded back into characters here to avoid signature invalidation
+      def euresource_escape(str)
+        CGI.escape(str).gsub(/%2F|%23/, "%2F" => "/", "%23" => "#")
       end
 
       def retrieve_public_key(app_uuid)

--- a/lib/mauth/version.rb
+++ b/lib/mauth/version.rb
@@ -1,3 +1,3 @@
 module MAuth
-  VERSION = '4.0.2'.freeze
+  VERSION = '4.0.3'.freeze
 end

--- a/spec/mauth_client_spec.rb
+++ b/spec/mauth_client_spec.rb
@@ -236,7 +236,7 @@ describe MAuth::Client do
         it "considers a request to be authentic even if the request_url must be CGI::escape'ed (after being escaped in Euresource's own idiosyncratic way) before authenticity is achieved" do
           ['/v1/users/pjones+1@mdsol.com', "! # $ & ' ( ) * + , / : ; = ? @ [ ]"].each do |path|
             # imagine what are on the requester's side now...
-            signed_path = CGI.escape(path).gsub!(/\w+/, '%2F' => '/', '%23' => '#') # This is what Euresource does to the path on the requester's side before the signing of the outgoing request occurs.
+            signed_path = CGI.escape(path).gsub!(/%2F|%23/, "%2F" => "/", "%23" => "#") # This is what Euresource does to the path on the requester's side before the signing of the outgoing request occurs.
             request = TestSignableRequest.new(:verb => 'GET', :request_url => signed_path)
             signed_request = @signing_mc.signed(request)
 

--- a/spec/mauth_client_spec.rb
+++ b/spec/mauth_client_spec.rb
@@ -236,7 +236,7 @@ describe MAuth::Client do
         it "considers a request to be authentic even if the request_url must be CGI::escape'ed (after being escaped in Euresource's own idiosyncratic way) before authenticity is achieved" do
           ['/v1/users/pjones+1@mdsol.com', "! # $ & ' ( ) * + , / : ; = ? @ [ ]"].each do |path|
             # imagine what are on the requester's side now...
-            signed_path = CGI.escape(path).gsub!('%2F','/') # This is what Euresource does to the path on the requester's side before the signing of the outgoing request occurs.
+            signed_path = CGI.escape(path).gsub!(/\w+/, '%2F' => '/', '%23' => '#') # This is what Euresource does to the path on the requester's side before the signing of the outgoing request occurs.
             request = TestSignableRequest.new(:verb => 'GET', :request_url => signed_path)
             signed_request = @signing_mc.signed(request)
 


### PR DESCRIPTION
Special characters in uri `com:mdsol:study_environments:6975285c-164d-4475-b848-25b0c8852510rqcwyungou&#65;902xcd7c9o` caused MAuth to reject the signed request. This PR adds the octothorpe/pound sign (`#`) to the gsub which already escapes the forward slash.

Specs updated to match.

This request should have been handled properly on the client's side, since # denotes a fragment. However, since the platform does not have a rigorous uri definition, this may occur again.