### PR TITLE
Fix forwarding of headers starting with http_ in the proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .bundle
 .yardoc
 
+/config
 /coverage
 /yardoc
 /log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # MAuth-Client History
 
+## v4.0.2
+- Restore original behavior in the proxy of forwarding of headers that begin with HTTP_ (except for HTTP_HOST) but removing the HTTP_.
+
 ## v4.0.1
 - Open source and publish this gem on rubygems.org, no functionality changes
 

--- a/lib/mauth/proxy.rb
+++ b/lib/mauth/proxy.rb
@@ -55,8 +55,8 @@ module MAuth
       request_env['rack.input'].rewind
       request_headers = {}
       request_env.each do |k, v|
-        if k.start_with?('HTTP_') && !%w(HTTP_HOST).include?(k)
-          name = $'
+        if k.start_with?('HTTP_') && k != 'HTTP_HOST'
+          name = k.sub(/\AHTTP_/, '')
           request_headers[name] = v
         end
       end

--- a/lib/mauth/version.rb
+++ b/lib/mauth/version.rb
@@ -1,3 +1,3 @@
 module MAuth
-  VERSION = '4.0.1'.freeze
+  VERSION = '4.0.2'.freeze
 end

--- a/mauth-client.gemspec
+++ b/mauth-client.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dice_bag', '>= 0.9', '< 2.0'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
+  spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'kender', '~> 0.4'
   spec.add_development_dependency 'rack-test', '~> 0.6.3'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/spec/proxy_spec.rb
+++ b/spec/proxy_spec.rb
@@ -54,5 +54,20 @@ describe MAuth::Proxy do
       mp.call(env)
       expect(double.headers["Expiry-time"]).to eq("3/6/1981 12:01.00")
     end
+
+    it 'forwards headers that begin with HTTP_ except for HTTP_HOST and removes the HTTP_ prefix' do
+      double = FakeConnection.new
+      allow(Faraday).to receive(:new).and_return(double)
+      mp = MAuth::Proxy.new(url)
+      http_headers = { 'HTTP_FOO' => 'bar_value', 'HTTP_HOST' => 'my_host', 'HTTP_BIZ' => 'buzz_value' }
+      mp.call(Rack::MockRequest.env_for(url, http_headers))
+      expect(double.headers['FOO']).to eq('bar_value')
+      expect(double.headers['BIZ']).to eq('buzz_value')
+      expect(double.headers.keys).to_not include('HTTP_HOST')
+      expect(double.headers.keys).to_not include('HOST')
+      expect(double.headers.keys).to_not include('HTTP_FOO')
+      expect(double.headers.keys).to_not include('HTTP_BIZ')
+    end
+
   end
 end


### PR DESCRIPTION
Having talked with @johngluckmdsol offline about https://github.com/mdsol/mauth-client-ruby/pull/11, this PR is inspired by his fix and from his discussion with @cabbott.  It seems like when the proxy was originally created in https://github.com/mdsol/mauth-client/pull/45 that the intent was to forward headers that begin with `HTTP_` but to remove the leading `HTTP_` (but to not forward `HTTP_HOST`).  This PR restores that behavior that was changed in https://github.com/mdsol/mauth-client/pull/106.

@jfeltesse-mdsol 