### PR TITLE
Drop support for ruby < 2.3.0 and update dev dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,23 +3,12 @@ cache: bundler
 sudo: false
 
 rvm:
-  - 2.2.10
   - 2.3.7
   - 2.4.4
   - 2.5.1
 
-matrix:
-  include:
-  - rvm: 2.1.10
-    gemfile: gemfiles/ruby_2.1.gemfile
+script: bundle exec rspec
 
-# https://github.com/travis-ci/travis-ci/issues/8978
-before_install:
-  - gem update --system
-  - gem install bundler # https://github.com/travis-ci/travis-ci/issues/9383
-  - bundle --version
-
-script: "bundle exec rspec"
 deploy:
   provider: rubygems
   gem: mauth-client

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# MAuth-Client History
+## v4.1.0
+- Drop support for Ruby < 2.3.0
+- Update development dependencies
 
 ## v4.0.4
 - Restore original behavior in the proxy of forwarding of headers that begin with HTTP_ (except for HTTP_HOST) but removing the HTTP_.

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
-require 'kender/tasks'
 
 RSpec::Core::RakeTask.new(:spec)
 

--- a/gemfiles/ruby_2.1.gemfile
+++ b/gemfiles/ruby_2.1.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gem "rack", "1.6.5"
-
-gemspec :path => "../"

--- a/lib/mauth/version.rb
+++ b/lib/mauth/version.rb
@@ -1,3 +1,3 @@
 module MAuth
-  VERSION = '4.0.4'.freeze
+  VERSION = '4.1.0'.freeze
 end

--- a/mauth-client.gemspec
+++ b/mauth-client.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Client for signing and authentication of requests and responses with mAuth authentication. Includes middleware for Rack and Faraday for incoming and outgoing requests and responses.'
   spec.homepage      = 'https://github.com/mdsol/mauth-client-ruby'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>= 2.1.0'
+  spec.required_ruby_version = '>= 2.3.0'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'
@@ -27,11 +27,9 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'byebug'
-  spec.add_development_dependency 'kender', '~> 0.4'
-  spec.add_development_dependency 'rack-test', '~> 0.6.3'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.4'
-  spec.add_development_dependency 'simplecov', '~> 0.12.0'
-  spec.add_development_dependency 'timecop', '~> 0.8.1'
-  spec.add_development_dependency 'uuidtools', '~> 2.1.5'
+  spec.add_development_dependency 'rack-test', '~> 1.1.0'
+  spec.add_development_dependency 'rake', '~> 12.0'
+  spec.add_development_dependency 'rspec', '~> 3.8'
+  spec.add_development_dependency 'simplecov', '~> 0.16'
+  spec.add_development_dependency 'timecop', '~> 0.9'
 end

--- a/spec/mauth_client_spec.rb
+++ b/spec/mauth_client_spec.rb
@@ -1,8 +1,11 @@
 require 'spec_helper'
 require 'faraday'
 require 'mauth/client'
+require 'securerandom'
 
 describe MAuth::Client do
+  let(:app_uuid) { SecureRandom.uuid }
+
   describe '#initialize' do
     it 'initializes without config' do
       mc = MAuth::Client.new
@@ -91,14 +94,15 @@ describe MAuth::Client do
 
   describe '#signed' do
     before { @request = TestSignableRequest.new(:verb => 'PUT', :request_url => '/', :body => 'himom') }
+
     it 'adds X-MWS-Time and X-MWS-Authentication headers when signing' do
-      mc = MAuth::Client.new(:private_key => OpenSSL::PKey::RSA.generate(2048), :app_uuid => UUIDTools::UUID.random_create.to_s)
+      mc = MAuth::Client.new(:private_key => OpenSSL::PKey::RSA.generate(2048), :app_uuid => app_uuid)
       signed_request = mc.signed(@request)
       expect(signed_request.headers.keys).to include('X-MWS-Authentication')
       expect(signed_request.headers.keys).to include('X-MWS-Time')
     end
     it "can't sign without a private key" do
-      mc = MAuth::Client.new(:app_uuid => UUIDTools::UUID.random_create.to_s)
+      mc = MAuth::Client.new(:app_uuid => app_uuid)
       expect{mc.signed(@request)}.to raise_error(MAuth::UnableToSignError)
     end
     it "can't sign without an app uuid" do
@@ -106,9 +110,10 @@ describe MAuth::Client do
       expect{mc.signed(@request)}.to raise_error(MAuth::UnableToSignError)
     end
   end
+
   describe '#signed_headers' do
     it 'returns a hash with X-MWS-Time and X-MWS-Authentication headers' do
-      mc = MAuth::Client.new(:private_key => OpenSSL::PKey::RSA.generate(2048), :app_uuid => UUIDTools::UUID.random_create.to_s)
+      mc = MAuth::Client.new(:private_key => OpenSSL::PKey::RSA.generate(2048), :app_uuid => app_uuid)
       signed_headers = mc.signed_headers(TestSignableRequest.new(:verb => 'PUT', :request_url => '/', :body => 'himom'))
       expect(signed_headers.keys).to include('X-MWS-Authentication')
       expect(signed_headers.keys).to include('X-MWS-Time')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require 'timecop'
-require 'uuidtools'
 require 'json'
 require 'rack/mock'
 


### PR DESCRIPTION
Ruby 2.2 [has reached EOL](https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/). Technically this gem is obviously still compatible with earlier versions so it's only about whether we want to support EOL rubies and the version the users of this gem are using.
AFAIK at medidata all ruby projects that are maintained and developed are at least at 2.3.x.

At the same time I cleaned up the dev dependencies:
- updated where applicable
- removed kender because it was not used
- removed uuidtools because securerandom does the job just fine now

I also cleaned up the travis file, the fixes around bundler are not needed anymore.

About the semver, doing a major vs minor bump in this case is subject to interpretation.
I think [this discussion](https://github.com/sparklemotion/nokogiri/issues/1568) on nokogiri's repo brings some good points in favor of not bumping major.

@mdsol/team-10 @ejennings-mdsol @johngluckmdsol 