### PR TITLE
Add Fossa CI to Travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,15 @@ rvm:
   - 2.4.4
   - 2.5.1
 
-script: bundle exec rspec
+install:
+  - bundle install --jobs=3 --retry=3
+  - |-
+    curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/mdsol/fossa_ci_scripts/master/travis_ci/fossa_install.sh | bash -s -- -b $TRAVIS_BUILD_DIR
+
+script:
+  - bundle exec rspec
+  - |-
+    curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/mdsol/fossa_ci_scripts/master/travis_ci/fossa_run.sh | bash -s -- -b $TRAVIS_BUILD_DIR
 
 deploy:
   provider: rubygems


### PR DESCRIPTION
FOSSA is a vendor which provides a platform for inventorying and ensuring compliance with Free and Open Source Software Licenses.

The FOSSA_API_KEY has been added to Travis and the changes in this PR follow the steps outlined in https://github.com/mdsol/fossa_ci_scripts/blob/master/travis_ci/SETUP.md -  Travis will NOT fail builds based on the results of the FOSSA Checks. The checks simply output a URL to a report which can be reviewed by security teams and auditors.

@mdsol/team-10 
