### PR TITLE
Update bundler version from 1.10 to 2.0.1

### DIFF
--- a/mauth-client.gemspec
+++ b/mauth-client.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rack'
   spec.add_dependency 'dice_bag', '>= 0.9', '< 2.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.10'
+  spec.add_development_dependency 'bundler', '~> 2.0.1'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'rack-test', '~> 1.1.0'
   spec.add_development_dependency 'rake', '~> 12.0'


### PR DESCRIPTION
my ruby=3.7.0, bundler=2.0.1, bundle install fails because "Could not find gem 'bundler (~> 1.10)' in any of the relevant sources"