### PR TITLE
Uses warning instead of error for logs when the mauth header is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v4.1.1
+- User warning level instead of error level for logs about missing mauth header.
+
 ## v4.1.0
 - Drop support for Ruby < 2.3.0
 - Update development dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## v4.1.1
-- User warning level instead of error level for logs about missing mauth header.
+- Use warning level instead of error level for logs about missing mauth header.
 
 ## v4.1.0
 - Drop support for Ruby < 2.3.0

--- a/lib/mauth/client.rb
+++ b/lib/mauth/client.rb
@@ -305,16 +305,13 @@ module MAuth
         token_valid!(object)
         signature_valid!(object)
       rescue MauthNotPresent => e
-        logger.warn "mAuth signature authentication failed for #{object.class}."
-        logger.warn e.message
+        logger.warn "mAuth signature not present. Exception: #{e.message}"
         raise
       rescue InauthenticError => e
-        logger.error "mAuth signature authentication failed for #{object.class}. encountered error:"
-        logger.error e.message
+        logger.error "mAuth signature authentication failed. Exception: #{e.message}"
         raise
       rescue UnableToAuthenticateError => e
-        logger.error "Unable to authenticate with MAuth. encountered error:"
-        logger.error e.message
+        logger.error "Unable to authenticate with MAuth. Exception: #{e.message}"
         raise
       end
 

--- a/lib/mauth/version.rb
+++ b/lib/mauth/version.rb
@@ -1,3 +1,3 @@
 module MAuth
-  VERSION = '4.1.0'.freeze
+  VERSION = '4.1.1'.freeze
 end

--- a/spec/mauth_client_spec.rb
+++ b/spec/mauth_client_spec.rb
@@ -137,7 +137,7 @@ describe MAuth::Client do
             expect(@authenticating_mc.authentic?(signed_request)).to be_truthy, message
           else
             expect {@authenticating_mc.authenticate!(signed_request)}.to(
-              raise_error(MAuth::InauthenticError, /Time verification failed for .*\. .* not within 300 of/), message)
+              raise_error(MAuth::InauthenticError, /Time verification failed\. .* not within 300 of/), message)
           end
         end
       end
@@ -147,7 +147,7 @@ describe MAuth::Client do
         signed_request.headers.delete('X-MWS-Time')
         expect{@authenticating_mc.authenticate!(signed_request)}.to raise_error(
                                                                         MAuth::InauthenticError,
-                                                                        /Time verification failed for .*\. No x-mws-time present\./
+                                                                        /Time verification failed\. No x-mws-time present\./
                                                                     )
       end
       it "considers a request with no X-MWS-Authentication to be inauthentic" do
@@ -164,7 +164,7 @@ describe MAuth::Client do
           signed_request = @signing_mc.signed(request)
           signed_request.headers['X-MWS-Authentication'] = signed_request.headers['X-MWS-Authentication'].sub(/\AMWS/, bad_token)
             expect{@authenticating_mc.authenticate!(signed_request)}.to raise_error(
-              MAuth::InauthenticError, /Token verification failed for .*\. Expected "MWS"; token was .*/)
+              MAuth::InauthenticError, /Token verification failed\. Expected "MWS"; token was .*/)
         end
       end
       [::Faraday::Error::ConnectionFailed, ::Faraday::Error::TimeoutError].each do |error_klass|
@@ -202,14 +202,6 @@ describe MAuth::Client do
           signed_request = @signing_mc.signed(request, :time => Time.now.to_i)
           allow(signed_request).to receive(:signature_app_uuid).and_return(nil)
           expect(@authenticating_mc.logger).to receive(:info).with("Mauth-client attempting to authenticate request from app with mauth app uuid [none provided] to app with mauth app uuid authenticator.")
-          @authenticating_mc.authentic?(signed_request) rescue nil
-        end
-
-        it 'logs an error when trying to log but getting an exception instead' do
-          request = TestSignableRequest.new(:verb => 'PUT', :request_url => '/', :body => 'himom')
-          signed_request = @signing_mc.signed(request, :time => Time.now.to_i)
-          allow(signed_request).to receive(:signature_app_uuid).and_raise('uh oh')
-          expect(@authenticating_mc.logger).to receive(:error).with("Mauth-client failed to log information about its attempts to authenticate the current request because uh oh")
           @authenticating_mc.authentic?(signed_request) rescue nil
         end
       end

--- a/spec/mauth_client_spec.rb
+++ b/spec/mauth_client_spec.rb
@@ -155,7 +155,7 @@ describe MAuth::Client do
         signed_request = @signing_mc.signed(request)
         signed_request.headers.delete('X-MWS-Authentication')
         expect{@authenticating_mc.authenticate!(signed_request)}.to raise_error(
-          MAuth::InauthenticError,
+          MAuth::MauthNotPresent,
           "Authentication Failed. No mAuth signature present; X-MWS-Authentication header is blank.")
       end
       it "considers a request with a bad MWS token to be inauthentic" do


### PR DESCRIPTION
Not having the header may be normal operation for some services, do not use error.
I've not touched other situations like when the header is present but the time is off, this may point to a service with a problem with its clock for instance.

@ejennings-mdsol  @mszenher 