### PR TITLE
[MCC-412658] Add V2 to benchmark

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,9 +21,8 @@ bundle exec rspec
 
 ## Running Benchmark
 
-If you make changes which could affect performance, please run the benchmark before and after the change as sanity check.
+If you make changes which could affect performance, please run the benchmark before and after the change as a sanity check.
 
 ```
 bundle exec rake benchmark
 ```
-

--- a/Rakefile
+++ b/Rakefile
@@ -56,19 +56,25 @@ task :benchmark do
   average_body = short_body * 1_000
   huge_body = average_body * 100
 
+  qs = 'don=quixote&quixote=don'
+
   short_request = TestSignableRequest.new(verb: 'PUT', request_url: '/', body: short_body)
+  qs_request = TestSignableRequest.new(verb: 'PUT', request_url: '/', body: short_body, query_string: qs)
   average_request = TestSignableRequest.new(verb: 'PUT', request_url: '/', body: average_body)
   huge_request = TestSignableRequest.new(verb: 'PUT', request_url: '/', body: huge_body)
 
   v1_short_signed_request = mc.signed_v1(short_request)
+  v1_qs_signed_request = mc.signed_v1(qs_request)
   v1_average_signed_request = mc.signed_v1(average_request)
   v1_huge_signed_request = mc.signed_v1(huge_request)
 
   v2_short_signed_request = mc.signed_v2(short_request)
+  v2_qs_signed_request = mc.signed_v1(qs_request)
   v2_average_signed_request = mc.signed_v2(average_request)
   v2_huge_signed_request = mc.signed_v1(huge_request)
 
   short_signed_request = mc.signed(short_request)
+  qs_signed_request = mc.signed(qs_request)
   average_signed_request = mc.signed(average_request)
   huge_signed_request = mc.signed(huge_request)
 
@@ -76,6 +82,9 @@ task :benchmark do
     bm.report('v1-sign-short') { mc.signed_v1(short_request) }
     bm.report('v2-sign-short') { mc.signed_v2(short_request) }
     bm.report('both-sign-short') { mc.signed(short_request) }
+    bm.report('v1-sign-qs') { mc.signed_v1(qs_request) }
+    bm.report('v2-sign-qs') { mc.signed_v2(qs_request) }
+    bm.report('both-sign-qs') { mc.signed(qs_request) }
     bm.report('v1-sign-average') { mc.signed_v1(average_request) }
     bm.report('v2-sign-average') { mc.signed_v2(average_request) }
     bm.report('both-sign-average') { mc.signed(average_request) }
@@ -90,6 +99,8 @@ task :benchmark do
   Benchmark.ips do |bm|
     bm.report('v1-authenticate-short') { authenticating_mc.authentic?(v1_short_signed_request) }
     bm.report('v2-authenticate-short') { authenticating_mc.authentic?(v2_short_signed_request) }
+    bm.report('v1-authenticate-qs') { authenticating_mc.authentic?(v1_qs_signed_request) }
+    bm.report('v2-authenticate-qs') { authenticating_mc.authentic?(v2_qs_signed_request) }
     bm.report('v1-authenticate-average') { authenticating_mc.authentic?(v1_average_signed_request) }
     bm.report('v2-authenticate-average') { authenticating_mc.authentic?(v2_average_signed_request) }
     bm.report('v1-authenticate-huge') { authenticating_mc.authentic?(v1_huge_signed_request) }

--- a/Rakefile
+++ b/Rakefile
@@ -26,11 +26,23 @@ class TestSignableRequest < MAuth::Request
   def x_mws_authentication
     headers['X-MWS-Authentication']
   end
+
+  def mcc_time
+    headers['MCC-Time']
+  end
+
+  def mcc_authentication
+    headers['MCC-Authentication']
+  end
 end
 
 desc 'Runs benchmarks for the library.'
 task :benchmark do
-  mc = MAuth::Client.new(private_key: OpenSSL::PKey::RSA.generate(2048), app_uuid: SecureRandom.uuid)
+  mc = MAuth::Client.new(
+    private_key: OpenSSL::PKey::RSA.generate(2048),
+    app_uuid: SecureRandom.uuid,
+    v2_only_sign_requests: false
+  )
   authenticating_mc = MAuth::Client.new(mauth_baseurl: 'http://whatever', mauth_api_version: 'v1')
 
   stubs = Faraday::Adapter::Test::Stubs.new
@@ -48,26 +60,42 @@ task :benchmark do
   average_request = TestSignableRequest.new(verb: 'PUT', request_url: '/', body: average_body)
   huge_request = TestSignableRequest.new(verb: 'PUT', request_url: '/', body: huge_body)
 
+  v1_short_signed_request = mc.signed_v1(short_request)
+  v1_average_signed_request = mc.signed_v1(average_request)
+  v1_huge_signed_request = mc.signed_v1(huge_request)
+
+  v2_short_signed_request = mc.signed_v2(short_request)
+  v2_average_signed_request = mc.signed_v2(average_request)
+  v2_huge_signed_request = mc.signed_v1(huge_request)
+
   short_signed_request = mc.signed(short_request)
   average_signed_request = mc.signed(average_request)
   huge_signed_request = mc.signed(huge_request)
 
   Benchmark.ips do |bm|
-    bm.report('sign short') { mc.signed(short_request) }
-    bm.report('sign average') { mc.signed(average_request) }
-    bm.report('sign huge') { mc.signed(huge_request) }
+    bm.report('v1-sign-short') { mc.signed_v1(short_request) }
+    bm.report('v2-sign-short') { mc.signed_v2(short_request) }
+    bm.report('both-sign-short') { mc.signed(short_request) }
+    bm.report('v1-sign-average') { mc.signed_v1(average_request) }
+    bm.report('v2-sign-average') { mc.signed_v2(average_request) }
+    bm.report('both-sign-average') { mc.signed(average_request) }
+    bm.report('v1-sign-huge') { mc.signed_v1(huge_request) }
+    bm.report('v2-sign-huge') { mc.signed_v2(huge_request) }
+    bm.report('both-sign-huge') { mc.signed(huge_request) }
     bm.compare!
   end
 
   puts "i/s means the number of signatures of a message per second.\n\n\n"
 
   Benchmark.ips do |bm|
-    bm.report('authenticate short') { authenticating_mc.authentic?(short_signed_request) }
-    bm.report('authenticate average') { authenticating_mc.authentic?(average_signed_request) }
-    bm.report('authenticate huge') { authenticating_mc.authentic?(huge_signed_request) }
+    bm.report('v1-authenticate-short') { authenticating_mc.authentic?(v1_short_signed_request) }
+    bm.report('v2-authenticate-short') { authenticating_mc.authentic?(v2_short_signed_request) }
+    bm.report('v1-authenticate-average') { authenticating_mc.authentic?(v1_average_signed_request) }
+    bm.report('v2-authenticate-average') { authenticating_mc.authentic?(v2_average_signed_request) }
+    bm.report('v1-authenticate-huge') { authenticating_mc.authentic?(v1_huge_signed_request) }
+    bm.report('v2-authenticate-huge') { authenticating_mc.authentic?(v2_huge_signed_request) }
     bm.compare!
   end
 
   puts 'i/s means the number of authentication checks of signatures per second.'
-
 end

--- a/Rakefile
+++ b/Rakefile
@@ -58,6 +58,15 @@ task :benchmark do
 
   qs = 'don=quixote&quixote=don'
 
+  puts <<-MSG
+
+    A short request has a body of 60 chars.
+    An average request has a body of 60,000 chars.
+    A huge request has a body of 6,000,000 chars.
+    A qs request has a body of 60 chars and a query string with two k/v pairs.
+    
+    MSG
+
   short_request = TestSignableRequest.new(verb: 'PUT', request_url: '/', body: short_body)
   qs_request = TestSignableRequest.new(verb: 'PUT', request_url: '/', body: short_body, query_string: qs)
   average_request = TestSignableRequest.new(verb: 'PUT', request_url: '/', body: average_body)

--- a/Rakefile
+++ b/Rakefile
@@ -64,7 +64,6 @@ task :benchmark do
   huge_request = TestSignableRequest.new(verb: 'PUT', request_url: '/', body: huge_body)
 
   v1_short_signed_request = mc.signed_v1(short_request)
-  v1_qs_signed_request = mc.signed_v1(qs_request)
   v1_average_signed_request = mc.signed_v1(average_request)
   v1_huge_signed_request = mc.signed_v1(huge_request)
 
@@ -82,7 +81,6 @@ task :benchmark do
     bm.report('v1-sign-short') { mc.signed_v1(short_request) }
     bm.report('v2-sign-short') { mc.signed_v2(short_request) }
     bm.report('both-sign-short') { mc.signed(short_request) }
-    bm.report('v1-sign-qs') { mc.signed_v1(qs_request) }
     bm.report('v2-sign-qs') { mc.signed_v2(qs_request) }
     bm.report('both-sign-qs') { mc.signed(qs_request) }
     bm.report('v1-sign-average') { mc.signed_v1(average_request) }
@@ -99,7 +97,6 @@ task :benchmark do
   Benchmark.ips do |bm|
     bm.report('v1-authenticate-short') { authenticating_mc.authentic?(v1_short_signed_request) }
     bm.report('v2-authenticate-short') { authenticating_mc.authentic?(v2_short_signed_request) }
-    bm.report('v1-authenticate-qs') { authenticating_mc.authentic?(v1_qs_signed_request) }
     bm.report('v2-authenticate-qs') { authenticating_mc.authentic?(v2_qs_signed_request) }
     bm.report('v1-authenticate-average') { authenticating_mc.authentic?(v1_average_signed_request) }
     bm.report('v2-authenticate-average') { authenticating_mc.authentic?(v2_average_signed_request) }

--- a/Rakefile
+++ b/Rakefile
@@ -50,7 +50,7 @@ task :benchmark do
     builder.adapter(:test, stubs)
   end
   stubs.post('/mauth/v1/authentication_tickets.json') { [204, {}, []] }
-  Faraday.stub(:new) { test_faraday }
+  allow(Faraday).to receive(:new).and_return(test_faraday)
 
   short_body = 'Somewhere in La Mancha, in a place I do not care to remember'
   average_body = short_body * 1_000
@@ -64,8 +64,8 @@ task :benchmark do
     An average request has a body of 60,000 chars.
     A huge request has a body of 6,000,000 chars.
     A qs request has a body of 60 chars and a query string with two k/v pairs.
-    
-    MSG
+
+  MSG
 
   short_request = TestSignableRequest.new(verb: 'PUT', request_url: '/', body: short_body)
   qs_request = TestSignableRequest.new(verb: 'PUT', request_url: '/', body: short_body, query_string: qs)
@@ -80,11 +80,6 @@ task :benchmark do
   v2_qs_signed_request = mc.signed_v1(qs_request)
   v2_average_signed_request = mc.signed_v2(average_request)
   v2_huge_signed_request = mc.signed_v1(huge_request)
-
-  short_signed_request = mc.signed(short_request)
-  qs_signed_request = mc.signed(qs_request)
-  average_signed_request = mc.signed(average_request)
-  huge_signed_request = mc.signed(huge_request)
 
   Benchmark.ips do |bm|
     bm.report('v1-sign-short') { mc.signed_v1(short_request) }


### PR DESCRIPTION
@mdsol/team-16 this adds V2 signing to the benchmark rake task.

Adding DNM because this is pointed at the `feature/v2-mauth-protocol`. 