### PR TITLE
[MCC-412658] Fix flickering spec

### DIFF
--- a/spec/support/shared_examples/authenticator_base.rb
+++ b/spec/support/shared_examples/authenticator_base.rb
@@ -19,11 +19,13 @@ shared_examples MAuth::Client::AuthenticatorBase do
     end
 
     it "considers an authentically-signed request to be authentic when it's within the allowed time range" do
+      Timecop.freeze(Time.now)
       [-300, -299, 299, 300].each do |time_offset|
         signed_request = client.signed(request, time: Time.now.to_i + time_offset)
         message = "expected request signed at #{time_offset} seconds to be authentic"
         expect(authenticating_mc.authentic?(signed_request)).to eq(true), message
       end
+      Timecop.return
     end
 
     it "considers an authentically-signed request to be inauthentic when it has no MCC-time" do
@@ -90,11 +92,13 @@ shared_examples MAuth::Client::AuthenticatorBase do
     end
 
     it "considers an authentically-signed request to be authentic when it's within the allowed time range" do
+      Timecop.freeze(Time.now)
       [-300, -299, 299, 300].each do |time_offset|
         signed_request = client.signed_v1(request, time: Time.now.to_i + time_offset)
         message = "expected request signed at #{time_offset} seconds to be authentic"
         expect(authenticating_mc.authentic?(signed_request)).to eq(true), message
       end
+      Timecop.return
     end
 
     it "considers an authentically-signed request to be inauthentic when it has no x-mws-time" do


### PR DESCRIPTION
@mdsol/team-16  

This PR adds the use of Timecop to two specs that can flicker because of rounding. You can see these spes, which were recently updated to include time offsets of `-300` and `300`, have failed CI on master on two past merge commits (828a6f75dbaa437b602d85c7eba4ce76580ae6aa and f76191e74fe55afa2d049457c2837e4653594272). 

We could also remove the time offsets of +/-300. 