### PR TITLE
[MCC-412658] Use RSA sign and RSA verify

### DIFF
--- a/lib/mauth/client/local_authenticator.rb
+++ b/lib/mauth/client/local_authenticator.rb
@@ -88,20 +88,21 @@ module MAuth
         )
 
         pubkey = OpenSSL::PKey::RSA.new(retrieve_public_key(object.signature_app_uuid))
+        actual = Base64.decode64(object.signature)
 
-        unless verify_signature_v2!(object, pubkey, expected_no_reencoding) ||
-           verify_signature_v2!(object, pubkey, expected_euresource_style_reencoding) ||
-           verify_signature_v2!(object, pubkey, expected_for_percent_reencoding)
+        unless verify_signature_v2!(object, actual, pubkey, expected_no_reencoding) ||
+           verify_signature_v2!(object, actual, pubkey, expected_euresource_style_reencoding) ||
+           verify_signature_v2!(object, actual, pubkey, expected_for_percent_reencoding)
           msg = "Signature verification failed for #{object.class}"
           log_inauthentic(object, msg)
           raise InauthenticError, msg
         end
       end
 
-      def verify_signature_v2!(object, pubkey, expected_str_to_sign)
+      def verify_signature_v2!(object, actual, pubkey, expected_str_to_sign)
         pubkey.verify(
           MAuth::Client::SIGNING_DIGEST,
-          Base64.decode64(object.signature),
+          actual,
           expected_str_to_sign
         )
       rescue OpenSSL::PKey::PKeyError => e

--- a/lib/mauth/client/local_authenticator.rb
+++ b/lib/mauth/client/local_authenticator.rb
@@ -95,7 +95,7 @@ module MAuth
         unless verify_signature_v2!(object, actual, pubkey, expected_no_reencoding) ||
            verify_signature_v2!(object, actual, pubkey, expected_euresource_style_reencoding) ||
            verify_signature_v2!(object, actual, pubkey, expected_for_percent_reencoding)
-          msg = "Signature verification failed for #{object.class}"
+          msg = "Signature inauthentic for #{object.class}"
           log_inauthentic(object, msg)
           raise InauthenticError, msg
         end
@@ -108,7 +108,7 @@ module MAuth
           expected_str_to_sign
         )
       rescue OpenSSL::PKey::PKeyError => e
-        msg = "Public key decryption of signature failed! #{e.class}: #{e.message}"
+        msg = "RSA verification of signature failed! #{e.class}: #{e.message}"
         log_inauthentic(object, msg)
         raise InauthenticError, msg
       end

--- a/lib/mauth/client/local_authenticator.rb
+++ b/lib/mauth/client/local_authenticator.rb
@@ -81,22 +81,21 @@ module MAuth
           query_string: euresource_escape(original_query_string.to_s)
         )
 
-        actual = actual_string_to_sign(object)
-
-        unless expected_no_reencoding == actual ||
-           expected_euresource_style_reencoding == actual ||
-           expected_for_percent_reencoding == actual
+        unless verify_signature!(object, expected_no_reencoding) ||
+           verify_signature!(object, expected_euresource_style_reencoding) ||
+           verify_signature!(object, expected_for_percent_reencoding)
           msg = "Signature verification failed for #{object.class}"
           log_inauthentic(object, msg)
           raise InauthenticError, msg
         end
       end
 
-      def actual_string_to_sign(object)
+      def verify_signature!(object, data)
         pubkey = OpenSSL::PKey::RSA.new(retrieve_public_key(object.signature_app_uuid))
+        digest = OpenSSL::Digest::SHA256.new
 
         begin
-          pubkey.public_decrypt(Base64.decode64(object.signature))
+          pubkey.verify(digest, Base64.decode64(object.signature), data)
         rescue OpenSSL::PKey::PKeyError => e
           msg = "Public key decryption of signature failed! #{e.class}: #{e.message}"
           log_inauthentic(object, msg)

--- a/lib/mauth/client/local_authenticator.rb
+++ b/lib/mauth/client/local_authenticator.rb
@@ -1,4 +1,5 @@
 require 'mauth/client/security_token_cacher'
+require 'mauth/client/signer'
 require 'openssl'
 
 # methods to verify the authenticity of signed requests and responses locally, retrieving
@@ -93,10 +94,9 @@ module MAuth
 
       def verify_signature!(object, expected_str_to_sign)
         pubkey = OpenSSL::PKey::RSA.new(retrieve_public_key(object.signature_app_uuid))
-        digest = OpenSSL::Digest::SHA512.new
 
         begin
-          pubkey.verify(digest, Base64.decode64(object.signature), expected_str_to_sign)
+          pubkey.verify(MAuth::Client::SIGNING_DIGEST, Base64.decode64(object.signature), expected_str_to_sign)
         rescue OpenSSL::PKey::PKeyError => e
           msg = "Public key decryption of signature failed! #{e.class}: #{e.message}"
           log_inauthentic(object, msg)

--- a/lib/mauth/client/local_authenticator.rb
+++ b/lib/mauth/client/local_authenticator.rb
@@ -34,24 +34,26 @@ module MAuth
         # reset the object original request_uri, just in case we need it again
         object.attributes_for_signing[:request_url] = original_request_uri
 
-        pubkey = OpenSSL::PKey::RSA.new(retrieve_public_key(object.signature_app_uuid))
+        begin
+          pubkey = OpenSSL::PKey::RSA.new(retrieve_public_key(object.signature_app_uuid))
+          actual = pubkey.public_decrypt(Base64.decode64(object.signature))
+        rescue OpenSSL::PKey::PKeyError => e
+          msg = "Public key decryption of signature failed! #{e.class}: #{e.message}"
+          log_inauthentic(object, msg)
+          raise InauthenticError, msg
+        end
 
-        unless verify_signature_v1!(object, pubkey, expected_no_reencoding) ||
-           verify_signature_v1!(object, pubkey, expected_euresource_style_reencoding) ||
-           verify_signature_v1!(object, pubkey, expected_for_percent_reencoding)
+        unless verify_signature_v1!(actual, expected_no_reencoding) ||
+           verify_signature_v1!(actual, expected_euresource_style_reencoding) ||
+           verify_signature_v1!(actual, expected_for_percent_reencoding)
           msg = "Signature verification failed for #{object.class}"
           log_inauthentic(object, msg)
           raise InauthenticError, msg
         end
       end
 
-      def verify_signature_v1!(object, pubkey, expected_str_to_sign)
-        hashed_str_to_sign = Digest::SHA512.hexdigest(expected_str_to_sign)
-        pubkey.public_decrypt(Base64.decode64(object.signature)) == hashed_str_to_sign
-      rescue OpenSSL::PKey::PKeyError => e
-        msg = "Public key decryption of signature failed! #{e.class}: #{e.message}"
-        log_inauthentic(object, msg)
-        raise InauthenticError, msg
+      def verify_signature_v1!(actual, expected_str_to_sign)
+        actual == Digest::SHA512.hexdigest(expected_str_to_sign)
       end
 
       def signature_valid_v2!(object)

--- a/lib/mauth/client/local_authenticator.rb
+++ b/lib/mauth/client/local_authenticator.rb
@@ -91,12 +91,12 @@ module MAuth
         end
       end
 
-      def verify_signature!(object, data)
+      def verify_signature!(object, expected_str_to_sign)
         pubkey = OpenSSL::PKey::RSA.new(retrieve_public_key(object.signature_app_uuid))
         digest = OpenSSL::Digest::SHA512.new
 
         begin
-          pubkey.verify(digest, Base64.decode64(object.signature), data)
+          pubkey.verify(digest, Base64.decode64(object.signature), expected_str_to_sign)
         rescue OpenSSL::PKey::PKeyError => e
           msg = "Public key decryption of signature failed! #{e.class}: #{e.message}"
           log_inauthentic(object, msg)

--- a/lib/mauth/client/local_authenticator.rb
+++ b/lib/mauth/client/local_authenticator.rb
@@ -1,4 +1,5 @@
 require 'mauth/client/security_token_cacher'
+require 'openssl'
 
 # methods to verify the authenticity of signed requests and responses locally, retrieving
 # public keys from the mAuth service as needed

--- a/lib/mauth/client/local_authenticator.rb
+++ b/lib/mauth/client/local_authenticator.rb
@@ -89,16 +89,16 @@ module MAuth
 
         pubkey = OpenSSL::PKey::RSA.new(retrieve_public_key(object.signature_app_uuid))
 
-        unless verify_signature!(object, pubkey, expected_no_reencoding) ||
-           verify_signature!(object, pubkey, expected_euresource_style_reencoding) ||
-           verify_signature!(object, pubkey, expected_for_percent_reencoding)
+        unless verify_signature_v2!(object, pubkey, expected_no_reencoding) ||
+           verify_signature_v2!(object, pubkey, expected_euresource_style_reencoding) ||
+           verify_signature_v2!(object, pubkey, expected_for_percent_reencoding)
           msg = "Signature verification failed for #{object.class}"
           log_inauthentic(object, msg)
           raise InauthenticError, msg
         end
       end
 
-      def verify_signature!(object, pubkey, expected_str_to_sign)
+      def verify_signature_v2!(object, pubkey, expected_str_to_sign)
         pubkey.verify(
           MAuth::Client::SIGNING_DIGEST,
           Base64.decode64(object.signature),

--- a/lib/mauth/client/local_authenticator.rb
+++ b/lib/mauth/client/local_authenticator.rb
@@ -93,7 +93,7 @@ module MAuth
 
       def verify_signature!(object, data)
         pubkey = OpenSSL::PKey::RSA.new(retrieve_public_key(object.signature_app_uuid))
-        digest = OpenSSL::Digest::SHA256.new
+        digest = OpenSSL::Digest::SHA512.new
 
         begin
           pubkey.verify(digest, Base64.decode64(object.signature), data)

--- a/lib/mauth/client/signer.rb
+++ b/lib/mauth/client/signer.rb
@@ -37,8 +37,8 @@ module MAuth
 
       def signed_headers_v1(object, attributes = {})
         attributes = { time: Time.now.to_i.to_s, app_uuid: client_app_uuid }.merge(attributes)
-        hashed_string_to_sign = object.string_to_sign_v1(attributes)
-        signature = self.signature_v1(hashed_string_to_sign)
+        string_to_sign = object.string_to_sign_v1(attributes)
+        signature = self.signature_v1(string_to_sign)
         { 'X-MWS-Authentication' => "#{MWS_TOKEN} #{client_app_uuid}:#{signature}", 'X-MWS-Time' => attributes[:time] }
       end
 

--- a/lib/mauth/client/signer.rb
+++ b/lib/mauth/client/signer.rb
@@ -1,4 +1,5 @@
 require 'openssl'
+require 'mauth/errors'
 
 # methods to sign requests and responses. part of MAuth::Client
 

--- a/lib/mauth/client/signer.rb
+++ b/lib/mauth/client/signer.rb
@@ -54,7 +54,8 @@ module MAuth
 
       def signature_v1(string_to_sign)
         assert_private_key(UNABLE_TO_SIGN_ERR)
-        Base64.encode64(private_key.private_encrypt(string_to_sign)).delete("\n")
+        hashed_string_to_sign = Digest::SHA512.hexdigest(string_to_sign)
+        Base64.encode64(private_key.private_encrypt(hashed_string_to_sign)).delete("\n")
       end
 
       def signature_v2(string_to_sign)

--- a/lib/mauth/client/signer.rb
+++ b/lib/mauth/client/signer.rb
@@ -54,7 +54,7 @@ module MAuth
 
       def signature_v2(string_to_sign)
         assert_private_key(UnableToSignError.new('mAuth client cannot sign without a private key!'))
-        digest = OpenSSL::Digest::SHA256.new
+        digest = OpenSSL::Digest::SHA512.new
         Base64.encode64(private_key.sign(digest, string_to_sign)).delete("\n")
       end
     end

--- a/lib/mauth/client/signer.rb
+++ b/lib/mauth/client/signer.rb
@@ -1,6 +1,5 @@
 require 'openssl'
 
-
 # methods to sign requests and responses. part of MAuth::Client
 
 module MAuth

--- a/lib/mauth/client/signer.rb
+++ b/lib/mauth/client/signer.rb
@@ -6,6 +6,7 @@ module MAuth
   class Client
     module Signer
       SIGNING_DIGEST = OpenSSL::Digest::SHA512.new
+      UNABLE_TO_SIGN_ERR = UnableToSignError.new('mAuth client cannot sign without a private key!')
 
       # takes an outgoing request or response object, and returns an object of the same class
       # whose headers are updated to include mauth's signature headers
@@ -50,12 +51,12 @@ module MAuth
       end
 
       def signature_v1(string_to_sign)
-        assert_private_key(UnableToSignError.new('mAuth client cannot sign without a private key!'))
+        assert_private_key(UNABLE_TO_SIGN_ERR)
         Base64.encode64(private_key.private_encrypt(string_to_sign)).delete("\n")
       end
 
       def signature_v2(string_to_sign)
-        assert_private_key(UnableToSignError.new('mAuth client cannot sign without a private key!'))
+        assert_private_key(UNABLE_TO_SIGN_ERR)
         Base64.encode64(private_key.sign(SIGNING_DIGEST, string_to_sign)).delete("\n")
       end
     end

--- a/lib/mauth/client/signer.rb
+++ b/lib/mauth/client/signer.rb
@@ -5,8 +5,9 @@ require 'mauth/errors'
 
 module MAuth
   class Client
+    SIGNING_DIGEST = OpenSSL::Digest::SHA512.new
+
     module Signer
-      SIGNING_DIGEST = OpenSSL::Digest::SHA512.new
       UNABLE_TO_SIGN_ERR = UnableToSignError.new('mAuth client cannot sign without a private key!')
 
       # takes an outgoing request or response object, and returns an object of the same class

--- a/lib/mauth/request_and_response.rb
+++ b/lib/mauth/request_and_response.rb
@@ -74,10 +74,9 @@ module MAuth
         raise(UnableToSignError, "Missing required attributes to sign: #{missing_attributes.inspect}\non object to sign: #{inspect}")
       end
 
-      string = self.class::SIGNATURE_COMPONENTS_V2.map do |k|
+      self.class::SIGNATURE_COMPONENTS_V2.map do |k|
         attrs_with_overrides[k].to_s.force_encoding('UTF-8')
       end.join("\n")
-      Digest::SHA512.hexdigest(string)
     end
 
     # sorts query string parameters by codepoint, uri encodes keys and values,

--- a/lib/mauth/request_and_response.rb
+++ b/lib/mauth/request_and_response.rb
@@ -35,8 +35,7 @@ module MAuth
       if missing_attributes.any?
         raise(UnableToSignError, "Missing required attributes to sign: #{missing_attributes.inspect}\non object to sign: #{inspect}")
       end
-      string = self.class::SIGNATURE_COMPONENTS.map { |k| attributes_for_signing[k].to_s }.join("\n")
-      Digest::SHA512.hexdigest(string)
+      self.class::SIGNATURE_COMPONENTS.map { |k| attributes_for_signing[k].to_s }.join("\n")
     end
 
     # the string to sign for V2 protocol will be (where LF is line feed character)

--- a/spec/client/signer_spec.rb
+++ b/spec/client/signer_spec.rb
@@ -89,7 +89,7 @@ describe MAuth::Client::Signer do
     end
 
     describe '#signature_v1' do
-      it 'it base 64 encodes the signed digest' do
+      it 'base 64 encodes the signed digest' do
         signature = client.signature_v1(string_to_sign)
         expect(Base64.decode64(signature)).to eq('encoded')
       end
@@ -101,7 +101,7 @@ describe MAuth::Client::Signer do
     end
 
     describe '#signature_v2' do
-      it 'it base 64 encodes the signed digest' do
+      it 'base 64 encodes the signed digest' do
         signature = client.signature_v2(string_to_sign)
         expect(Base64.decode64(signature)).to eq('encoded_message')
       end

--- a/spec/client/signer_spec.rb
+++ b/spec/client/signer_spec.rb
@@ -80,4 +80,43 @@ describe MAuth::Client::Signer do
     end
   end
 
+  describe 'signature methods' do
+    let(:string_to_sign) { 'dummy str' }
+    let(:mock_pkey) { double('private_key', sign: 'encoded_message', private_encrypt: 'encoded') }
+
+    before do
+      allow(client).to receive(:private_key).and_return(mock_pkey)
+    end
+
+    describe '#signature_v1' do
+      it 'it base 64 encodes the signed digest' do
+        signature = client.signature_v1(string_to_sign)
+        expect(Base64.decode64(signature)).to eq('encoded')
+      end
+
+      it 'handles newlines appropriately' do
+        signature = client.signature_v1(string_to_sign)
+        expect(signature !~ /\n/).to be(true)
+      end
+    end
+
+    describe '#signature_v2' do
+      it 'it base 64 encodes the signed digest' do
+        signature = client.signature_v2(string_to_sign)
+        expect(Base64.decode64(signature)).to eq('encoded_message')
+      end
+
+      it 'handles newlines appropriately' do
+        signature = client.signature_v2(string_to_sign)
+        expect(signature !~ /\n/).to be(true)
+      end
+
+      it 'calls `sign` with an OpenSSL SHA512 digest' do
+        expect(mock_pkey).to receive(:sign)
+          .with(an_instance_of(OpenSSL::Digest::SHA512), string_to_sign)
+        client.signature_v2(string_to_sign)
+      end
+    end
+  end
+
 end

--- a/spec/signable_spec.rb
+++ b/spec/signable_spec.rb
@@ -91,7 +91,7 @@ describe MAuth::Signable do
         dummy_req = dummy_cls.new(req_attrs)
         str = dummy_req.string_to_sign_v2({})
 
-        string_to_sign.split("\n\r").each do |component|
+        str.split("\n\r").each do |component|
           expect(component.encoding.to_s).to eq('UTF-8')
         end
       end
@@ -133,7 +133,7 @@ describe MAuth::Signable do
         dummy_req = dummy_cls.new(resp_attrs)
         str = dummy_req.string_to_sign_v2({})
 
-        string_to_sign.split("\n\r").each do |component|
+        str.split("\n\r").each do |component|
           expect(component.encoding.to_s).to eq('UTF-8')
         end
       end

--- a/spec/signable_spec.rb
+++ b/spec/signable_spec.rb
@@ -87,26 +87,13 @@ describe MAuth::Signable do
         end
       end
 
-      it 'hashes the request body with SHA512' do
-        expect(Digest::SHA512).to receive(:hexdigest).with(req_attrs[:body]).once
-        # this spec fails unless we expect Digest::SHA512 to be called again
-        # with the concatenated signature components
-        expect(Digest::SHA512).to receive(:hexdigest).with(anything)
-        dummy_req = dummy_cls.new(req_attrs)
-        dummy_req.string_to_sign_v2({})
-      end
-
       it 'enforces UTF-8 encoding for all components of the string to sign' do
-        # this spec fails unless we expect Digest::SHA512 to be on the body first
-        expect(Digest::SHA512).to receive(:hexdigest).with(req_attrs[:body]).once
-        expect(Digest::SHA512).to receive(:hexdigest) do |string_to_sign|
-          string_to_sign.split("\n\r").each do |component|
-            expect(component.encoding.to_s).to eq('UTF-8')
-          end
-        end
-
         dummy_req = dummy_cls.new(req_attrs)
-        dummy_req.string_to_sign_v2({})
+        str = dummy_req.string_to_sign_v2({})
+
+        string_to_sign.split("\n\r").each do |component|
+          expect(component.encoding.to_s).to eq('UTF-8')
+        end
       end
 
       # we have this spec because Faraday and Rack handle empty request bodies
@@ -142,13 +129,13 @@ describe MAuth::Signable do
         expect { dummy_resp.string_to_sign_v2({}) }.not_to raise_error
       end
 
-      it 'hashes the request body with SHA512' do
-        expect(Digest::SHA512).to receive(:hexdigest).with(resp_attrs[:body]).once
-        # this spec fails unless we expect Digest::SHA512 to be called again
-        # with the concatenated signature components
-        expect(Digest::SHA512).to receive(:hexdigest).with(anything)
-        dummy_resp = dummy_cls.new(resp_attrs)
-        dummy_resp.string_to_sign_v2({})
+      it 'enforces UTF-8 encoding for all components of the string to sign' do
+        dummy_req = dummy_cls.new(resp_attrs)
+        str = dummy_req.string_to_sign_v2({})
+
+        string_to_sign.split("\n\r").each do |component|
+          expect(component.encoding.to_s).to eq('UTF-8')
+        end
       end
     end
   end

--- a/spec/signable_spec.rb
+++ b/spec/signable_spec.rb
@@ -135,7 +135,7 @@ describe MAuth::Signable do
         expect { dummy_resp.string_to_sign_v2({}) }.not_to raise_error
       end
 
-      it 'hashes the request body with SHA512' do
+      it 'hashes the response body with SHA512' do
         expect(Digest::SHA512).to receive(:hexdigest).with(resp_attrs[:body]).once
         dummy_req = dummy_cls.new(resp_attrs)
         dummy_req.string_to_sign_v2({})

--- a/spec/signable_spec.rb
+++ b/spec/signable_spec.rb
@@ -87,6 +87,12 @@ describe MAuth::Signable do
         end
       end
 
+      it 'hashes the request body with SHA512' do
+        expect(Digest::SHA512).to receive(:hexdigest).with(req_attrs[:body]).once
+        dummy_req = dummy_cls.new(req_attrs)
+        dummy_req.string_to_sign_v2({})
+      end
+
       it 'enforces UTF-8 encoding for all components of the string to sign' do
         dummy_req = dummy_cls.new(req_attrs)
         str = dummy_req.string_to_sign_v2({})
@@ -127,6 +133,12 @@ describe MAuth::Signable do
         resp_attrs.delete(:body_digest)
         dummy_resp = dummy_cls.new(resp_attrs)
         expect { dummy_resp.string_to_sign_v2({}) }.not_to raise_error
+      end
+
+      it 'hashes the request body with SHA512' do
+        expect(Digest::SHA512).to receive(:hexdigest).with(resp_attrs[:body]).once
+        dummy_req = dummy_cls.new(resp_attrs)
+        dummy_req.string_to_sign_v2({})
       end
 
       it 'enforces UTF-8 encoding for all components of the string to sign' do


### PR DESCRIPTION
@mdsol/team-16 
[JIRA](https://jira.mdsol.com/browse/MCC-412658)

This PR updates the mAuth V2 protocol to use the RSA `sign` and `verify` standard methods for digital signature schemes (see docs for these methods [here](http://ruby-doc.org/stdlib-2.6.1/libdoc/openssl/rdoc/OpenSSL/PKey/PKey.html)). This is in response to concerns raised about the current use of the non-standard `private_encrypt` in this issue: https://github.com/mdsol/mauth/issues/59.

 