### PR TITLE
[MCC-412658] Make casing of error consistent

### DIFF
--- a/exe/mauth-client
+++ b/exe/mauth-client
@@ -251,7 +251,7 @@ end
 
 begin
   response = connection.run_request(httpmethod.downcase.to_sym, url, body, headers)
-rescue MAuth::InauthenticError, MAuth::UnableToAuthenticateError, MAuth::MauthNotPresent, MAuth::MissingV2Error => e
+rescue MAuth::InauthenticError, MAuth::UnableToAuthenticateError, MAuth::MAuthNotPresent, MAuth::MissingV2Error => e
   if $options[:color].nil? ? STDERR.tty? : $options[:color]
     class_color = Term::ANSIColor.method(e.is_a?(MAuth::UnableToAuthenticateError) ? :intense_yellow : :intense_red)
     message_color = Term::ANSIColor.method(e.is_a?(MAuth::UnableToAuthenticateError) ? :yellow : :red)

--- a/lib/mauth/client/authenticator_base.rb
+++ b/lib/mauth/client/authenticator_base.rb
@@ -12,7 +12,7 @@ module MAuth
         begin
           authenticate!(object)
           true
-        rescue InauthenticError, MauthNotPresent, MissingV2Error
+        rescue InauthenticError, MAuthNotPresent, MissingV2Error
           false
         end
       end
@@ -36,7 +36,7 @@ module MAuth
           sub_str = v2_only_authenticate? ? '' : 'X-MWS-Authentication header is blank, '
           msg = "Authentication Failed. No mAuth signature present; #{sub_str}MCC-Authentication header is blank."
           logger.warn("mAuth signature not present on #{object.class}. Exception: #{msg}")
-          raise MauthNotPresent, msg
+          raise MAuthNotPresent, msg
         end
       end
 

--- a/lib/mauth/errors.rb
+++ b/lib/mauth/errors.rb
@@ -14,7 +14,7 @@ module MAuth
   class InauthenticError < StandardError; end
 
   # Used when the incoming request does not contain any mAuth related information
-  class MauthNotPresent < StandardError; end
+  class MAuthNotPresent < StandardError; end
 
   # required information for signing was missing
   class UnableToSignError < StandardError; end

--- a/lib/mauth/rack.rb
+++ b/lib/mauth/rack.rb
@@ -74,7 +74,7 @@ module MAuth
       def response_for_missing_v2(env)
         handle_head(env) do
           body = {
-            'type' => 'errors:application_authentication:missing_v2',
+            'type' => 'errors:mauth:missing_v2',
             'title' => 'This service requires mAuth v2 mcc-authentication header. Upgrade your mAuth library and configure it properly.'
           }
           [401, { 'Content-Type' => 'application/json' }, [JSON.pretty_generate(body)]]

--- a/lib/mauth/rack.rb
+++ b/lib/mauth/rack.rb
@@ -74,7 +74,7 @@ module MAuth
       def response_for_missing_v2(env)
         handle_head(env) do
           body = {
-            'type' => 'errors:mauth:missing_v2',
+            'type' => 'errors:application_authentication:missing_v2',
             'title' => 'This service requires mAuth v2 mcc-authentication header. Upgrade your mAuth library and configure it properly'
           }
           [401, { 'Content-Type' => 'application/json' }, [JSON.pretty_generate(body)]]

--- a/lib/mauth/rack.rb
+++ b/lib/mauth/rack.rb
@@ -75,7 +75,7 @@ module MAuth
         handle_head(env) do
           body = {
             'type' => 'errors:application_authentication:missing_v2',
-            'title' => 'This service requires mAuth v2 mcc-authentication header. Upgrade your mAuth library and configure it properly'
+            'title' => 'This service requires mAuth v2 mcc-authentication header. Upgrade your mAuth library and configure it properly.'
           }
           [401, { 'Content-Type' => 'application/json' }, [JSON.pretty_generate(body)]]
         end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -90,7 +90,7 @@ describe MAuth::Rack do
         expect(401).to eq(status)
         expect(headers['Content-Type']).to eq('application/json')
         expect(JSON.parse(body.join)).to eq({
-          'type' => 'errors:mauth:missing_v2',
+          'type' => 'errors:application_authentication:missing_v2',
           'title' => 'This service requires mAuth v2 mcc-authentication header. Upgrade your mAuth library and configure it properly'
         })
       end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -90,7 +90,7 @@ describe MAuth::Rack do
         expect(401).to eq(status)
         expect(headers['Content-Type']).to eq('application/json')
         expect(JSON.parse(body.join)).to eq({
-          'type' => 'errors:application_authentication:missing_v2',
+          'type' => 'errors:mauth:missing_v2',
           'title' => 'This service requires mAuth v2 mcc-authentication header. Upgrade your mAuth library and configure it properly'
         })
       end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -91,7 +91,7 @@ describe MAuth::Rack do
         expect(headers['Content-Type']).to eq('application/json')
         expect(JSON.parse(body.join)).to eq({
           'type' => 'errors:mauth:missing_v2',
-          'title' => 'This service requires mAuth v2 mcc-authentication header. Upgrade your mAuth library and configure it properly'
+          'title' => 'This service requires mAuth v2 mcc-authentication header. Upgrade your mAuth library and configure it properly.'
         })
       end
     end

--- a/spec/support/shared_examples/authenticator_base.rb
+++ b/spec/support/shared_examples/authenticator_base.rb
@@ -163,7 +163,7 @@ shared_examples MAuth::Client::AuthenticatorBase do
       signed_request.headers.delete('X-MWS-Authentication')
       signed_request.headers.delete('MCC-Authentication')
       expect { authenticating_mc.authenticate!(signed_request) }.to raise_error(
-        MAuth::MauthNotPresent,
+        MAuth::MAuthNotPresent,
         'Authentication Failed. No mAuth signature present; X-MWS-Authentication ' \
         'header is blank, MCC-Authentication header is blank.'
       )
@@ -174,7 +174,7 @@ shared_examples MAuth::Client::AuthenticatorBase do
       signed_request.headers['X-MWS-Authentication'] = ''
       signed_request.headers['MCC-Authentication'] = ''
       expect { authenticating_mc.authenticate!(signed_request) }.to raise_error(
-        MAuth::MauthNotPresent,
+        MAuth::MAuthNotPresent,
         'Authentication Failed. No mAuth signature present; X-MWS-Authentication' \
         ' header is blank, MCC-Authentication header is blank.'
       )
@@ -202,7 +202,7 @@ shared_examples MAuth::Client::AuthenticatorBase do
       signed_request.headers.delete('MCC-Authentication')
       signed_request.headers.delete('X-MWS-Authentication')
       expect { authenticating_mc.authenticate!(signed_request) }.to raise_error(
-        MAuth::MauthNotPresent,
+        MAuth::MAuthNotPresent,
         'Authentication Failed. No mAuth signature present; MCC-Authentication header is blank.'
       )
     end
@@ -212,7 +212,7 @@ shared_examples MAuth::Client::AuthenticatorBase do
       signed_request.headers['MCC-Authentication'] = ''
       signed_request.headers.delete('X-MWS-Authentication')
       expect { authenticating_mc.authenticate!(signed_request) }.to raise_error(
-        MAuth::MauthNotPresent,
+        MAuth::MAuthNotPresent,
         'Authentication Failed. No mAuth signature present; MCC-Authentication header is blank.'
       )
     end


### PR DESCRIPTION
@mdsol/team-16 last small fixes for v5. I noticed the casing was inconsistent in the `MauthNotPresent` error name while i was updating mauth service to use the new client. This is a simple find and replace PR.