### PR TITLE
[MCC-413109] Fix Euresource escaping of query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v5.0.1
+- Update euresource escaping of query string.
+
 ## v5.0.0
 - Add support for MWSV2 protocol.
 - Change request signing to sign with both V1 and V2 protocols by default.

--- a/lib/mauth/client/local_authenticator.rb
+++ b/lib/mauth/client/local_authenticator.rb
@@ -43,21 +43,13 @@ module MAuth
           raise InauthenticError, msg
         end
 
-        return nil if verify_signature_v1!(actual, expected_no_reencoding)
-
-        if verify_signature_v1!(actual, expected_euresource_style_reencoding)
-          logger.info("Signature successfully authenticated with euresource style reencoding." \
-            " url: '#{original_request_uri}'.")
-          return nil
-        elsif verify_signature_v1!(actual, expected_for_percent_reencoding)
-          logger.info("Signature successfully authenticated with simple percent reencoding." \
-          " url: '#{original_request_uri}'.")
-          return nil
+        unless verify_signature_v1!(actual, expected_no_reencoding) ||
+           verify_signature_v1!(actual, expected_euresource_style_reencoding) ||
+           verify_signature_v1!(actual, expected_for_percent_reencoding)
+          msg = "Signature verification failed for #{object.class}"
+          log_inauthentic(object, msg)
+          raise InauthenticError, msg
         end
-
-        msg = "Signature verification failed for #{object.class}"
-        log_inauthentic(object, msg)
-        raise InauthenticError, msg
       end
 
       def verify_signature_v1!(actual, expected_str_to_sign)
@@ -100,21 +92,13 @@ module MAuth
         pubkey = OpenSSL::PKey::RSA.new(retrieve_public_key(object.signature_app_uuid))
         actual = Base64.decode64(object.signature)
 
-        return nil if verify_signature_v2!(object, actual, pubkey, expected_no_reencoding)
-
-        if verify_signature_v2!(object, actual, pubkey, expected_euresource_style_reencoding)
-          logger.info("Signature successfully authenticated with euresource style reencoding." \
-            " url: '#{original_request_uri}'. query string: '#{original_query_string}'")
-          return nil
-        elsif verify_signature_v2!(object, actual, pubkey, expected_for_percent_reencoding)
-          logger.info("Signature successfully authenticated with simple percent reencoding." \
-            " url: '#{original_request_uri}'. query string: '#{original_query_string}'")
-          return nil
+        unless verify_signature_v2!(object, actual, pubkey, expected_no_reencoding) ||
+           verify_signature_v2!(object, actual, pubkey, expected_euresource_style_reencoding) ||
+           verify_signature_v2!(object, actual, pubkey, expected_for_percent_reencoding)
+          msg = "Signature inauthentic for #{object.class}"
+          log_inauthentic(object, msg)
+          raise InauthenticError, msg
         end
-
-        msg = "Signature inauthentic for #{object.class}"
-        log_inauthentic(object, msg)
-        raise InauthenticError, msg
       end
 
       def verify_signature_v2!(object, actual, pubkey, expected_str_to_sign)

--- a/lib/mauth/client/local_authenticator.rb
+++ b/lib/mauth/client/local_authenticator.rb
@@ -136,6 +136,10 @@ module MAuth
         CGI.escape(str).gsub(/%2F|%23/, '%2F' => '/', '%23' => '#')
       end
 
+      # Euresource encodes keys and values of query params but does not encode the '='
+      # that separates keys and values and the '&' that separate k/v pairs
+      # Euresource currently adds query parameters via the following method:
+      # https://www.rubydoc.info/gems/addressable/2.3.4/Addressable/URI#query_values=-instance_method
       def euresource_query_escape(str)
         CGI.escape(str).gsub(/%3D|%26/, '%3D' => '=', '%26' => '&')
       end

--- a/lib/mauth/client/local_authenticator.rb
+++ b/lib/mauth/client/local_authenticator.rb
@@ -86,7 +86,7 @@ module MAuth
           time: object.mcc_time,
           app_uuid: object.signature_app_uuid,
           request_url: euresource_escape(original_request_uri.to_s),
-          query_string: euresource_escape(original_query_string.to_s)
+          query_string: euresource_query_escape(original_query_string.to_s)
         )
 
         pubkey = OpenSSL::PKey::RSA.new(retrieve_public_key(object.signature_app_uuid))
@@ -118,6 +118,10 @@ module MAuth
       #   they are decoded back into characters here to avoid signature invalidation
       def euresource_escape(str)
         CGI.escape(str).gsub(/%2F|%23/, '%2F' => '/', '%23' => '#')
+      end
+
+      def euresource_query_escape(str)
+        CGI.escape(str).gsub(/%3D|%26/, '%3D' => '=', '%26' => '&')
       end
 
       def retrieve_public_key(app_uuid)

--- a/lib/mauth/client/local_authenticator.rb
+++ b/lib/mauth/client/local_authenticator.rb
@@ -46,10 +46,12 @@ module MAuth
         return nil if verify_signature_v1!(actual, expected_no_reencoding)
 
         if verify_signature_v1!(actual, expected_euresource_style_reencoding)
-          logger.info('Signature successfully authenticated with euresource style reencoding')
+          logger.info("Signature successfully authenticated with euresource style reencoding." \
+            " url: '#{original_request_uri}'.")
           return nil
         elsif verify_signature_v1!(actual, expected_for_percent_reencoding)
-          logger.info('Signature successfully authenticated with simple percent reencoding')
+          logger.info("Signature successfully authenticated with simple percent reencoding." \
+          " url: '#{original_request_uri}'.")
           return nil
         end
 
@@ -101,10 +103,12 @@ module MAuth
         return nil if verify_signature_v2!(object, actual, pubkey, expected_no_reencoding)
 
         if verify_signature_v2!(object, actual, pubkey, expected_euresource_style_reencoding)
-          logger.info('Signature successfully authenticated with euresource style reencoding')
+          logger.info("Signature successfully authenticated with euresource style reencoding." \
+            " url: '#{original_request_uri}'. query string: '#{original_query_string}'")
           return nil
         elsif verify_signature_v2!(object, actual, pubkey, expected_for_percent_reencoding)
-          logger.info('Signature successfully authenticated with simple percent reencoding')
+          logger.info("Signature successfully authenticated with simple percent reencoding." \
+            " url: '#{original_request_uri}'. query string: '#{original_query_string}'")
           return nil
         end
 

--- a/lib/mauth/version.rb
+++ b/lib/mauth/version.rb
@@ -1,3 +1,3 @@
 module MAuth
-  VERSION = '5.0.0'.freeze
+  VERSION = '5.0.1'.freeze
 end

--- a/spec/client/local_authenticator_spec.rb
+++ b/spec/client/local_authenticator_spec.rb
@@ -7,7 +7,7 @@ require_relative '../support/shared_examples/authenticator_base.rb'
 
 describe MAuth::Client::LocalAuthenticator do
   include_context 'client'
-  
+
   describe '#authentic?' do
     let(:v2_only_authenticate) { false }
     let(:authenticating_mc) do
@@ -124,7 +124,7 @@ describe MAuth::Client::LocalAuthenticator do
         ].each do |path, qs|
           # imagine what are on the requester's side now...
           signed_path = CGI.escape(path).gsub(/%2F|%23/, "%2F" => "/", "%23" => "#") # This is what Euresource does to the path on the requester's side before the signing of the outgoing request occurs.
-          signed_qs = CGI.escape(qs).gsub(/%2F|%23/, "%2F" => "/", "%23" => "#")
+          signed_qs = CGI.escape(qs).gsub(/%3D|%26/, '%3D' => '=', '%26' => '&')
           req_w_path = TestSignableRequest.new(verb: 'GET', request_url: signed_path, query_string: signed_qs)
           signed_request = client.signed(req_w_path)
 


### PR DESCRIPTION
@mdsol/team-16 

@yboyadjan observed that query strings with special characters were not being correctly authenticated when submitted via v2 mAuth authentication tickets. This demonstrated an issue with the way we're doing the special euresource escaping for query strings. 

Eureka client generates query strings using the the method documented [here](https://www.rubydoc.info/gems/addressable/2.3.4/Addressable/URI#query_values=-instance_method) on [this line](https://github.com/mdsol/eureka-client/blob/0af64745dfc3bc99554e28b49d95dbd9900d042c/lib/google/api_client/discovery/method.rb#L175). It encodes all special characters in query param keys and values (including `/` and `#`) but does not encode the `=` and `&` that connect keys and values and k/v pairs. Previously I used the same `euresource_escape` function that we used for the request url. In this PR I updated our query string escaping to reflect what euresource actually does.

When authenticating mauth-client generates three signatures that it matches with the actual signature: one with no re-encoding, one with what the code calls special euresource encoding, and one with simple percent reencoding. We do this, as the comment in the code explains, because 

>        # We are in an unfortunate situation in which Euresource is percent-encoding parts of paths, but not
>        # all of them.  In particular, Euresource is percent-encoding all special characters save for '/'.
>        # Also, unfortunately, Nginx unencodes URIs before sending them off to served applications, though
>        # other web servers (particularly those we typically use for local testing) do not.  The various forms
>        # of the expected string to sign are meant to cover the main cases.
>        # TODO:  Revisit and simplify this unfortunate situation.

I think that we very rarely successfully authenticate with anything other than the original string to sign. In order to revisit and potentially simplify this situation we need to know how often we hit these special cases were we need reencoding in our authentication so I added logging to help determine this.