### PR TITLE
Fix to not raise FrozenError when string to sign contains frozen value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v5.0.2
+- Fix to not raise FrozenError when string to sign contains frozen value.
+
 ## v5.0.1
 - Update euresource escaping of query string.
 

--- a/lib/mauth/request_and_response.rb
+++ b/lib/mauth/request_and_response.rb
@@ -74,7 +74,7 @@ module MAuth
       end
 
       self.class::SIGNATURE_COMPONENTS_V2.map do |k|
-        attrs_with_overrides[k].to_s.force_encoding('UTF-8')
+        attrs_with_overrides[k].to_s.dup.force_encoding('UTF-8')
       end.join("\n")
     end
 

--- a/lib/mauth/version.rb
+++ b/lib/mauth/version.rb
@@ -1,3 +1,3 @@
 module MAuth
-  VERSION = '5.0.1'.freeze
+  VERSION = '5.0.2'.freeze
 end

--- a/spec/signable_spec.rb
+++ b/spec/signable_spec.rb
@@ -9,6 +9,7 @@ describe MAuth::Signable do
     { verb: 'PUT', request_url: '/', body: '{}', query_string: 'k=v' }
       .merge(more_attrs)
   end
+  let(:frozen_req_attrs) { req_attrs.each_with_object({}) { |(k, v), h| h[k] = v.is_a?(String) ? v.freeze : v } }
   let(:dummy_cls) do
     class Dummy
       include MAuth::Signable
@@ -100,6 +101,11 @@ describe MAuth::Signable do
         str.split("\n\r").each do |component|
           expect(component.encoding.to_s).to eq('UTF-8')
         end
+      end
+
+      it 'does not raise when all string components of the string to sign are frozen' do
+        dummy_req = dummy_cls.new(frozen_req_attrs)
+        expect { dummy_req.string_to_sign_v2({}) }.not_to raise_error
       end
 
       # we have this spec because Faraday and Rack handle empty request bodies


### PR DESCRIPTION
## Background

The following error is raised when `# frozen_string_literal: true` is in use:
```
FrozenError: can't modify frozen String
/opt/ruby/gems/2.5.0/gems/mauth-client-5.0.1/lib/mauth/request_and_response.rb:77:in `force_encoding'
```
Similar issue found in Sinatra: 
https://github.com/sinatra/sinatra/issues/1478

## Changes Summary

Simply using the `dup` method.

@mdsol/team-16 @mdsol/team-10 