### PR TITLE
Add cross-platform signature value checks

### DIFF
--- a/spec/client/signer_spec.rb
+++ b/spec/client/signer_spec.rb
@@ -119,4 +119,33 @@ describe MAuth::Client::Signer do
     end
   end
 
+  describe 'cross platform signature testing' do
+    let(:testing_info) { JSON.parse(IO.read('spec/fixtures/mauth_signature_testing.json'), symbolize_names: true) }
+    let(:client) do
+      MAuth::Client.new(
+        private_key: testing_info[:private_key],
+        app_uuid: testing_info[:app_uuid]
+      )
+    end
+
+    let(:binary_file_body) { File.binread('spec/fixtures/blank.jpeg') }
+
+    let(:attributes_for_signing) do
+      testing_info[:attributes_for_signing].tap do |attributes|
+        attributes[:body] = binary_file_body
+      end
+    end
+
+    let(:request) { MAuth::Request.new(attributes_for_signing) }
+
+    it 'returns accurate v1 signature' do
+      signature_v1 = client.signature_v1(request.string_to_sign_v1({}))
+      expect(signature_v1).to eq(testing_info[:signatures][:v1])
+    end
+
+    it 'returns accurate v2 signature' do
+      signature_v2 = client.signature_v2(request.string_to_sign_v2({}))
+      expect(signature_v2).to eq(testing_info[:signatures][:v2])
+    end
+  end
 end

--- a/spec/client/signer_spec.rb
+++ b/spec/client/signer_spec.rb
@@ -128,24 +128,39 @@ describe MAuth::Client::Signer do
       )
     end
 
-    let(:binary_file_body) { File.binread('spec/fixtures/blank.jpeg') }
-
+    let(:request) { MAuth::Request.new(attributes_for_signing) }
     let(:attributes_for_signing) do
       testing_info[:attributes_for_signing].tap do |attributes|
-        attributes[:body] = binary_file_body
+        attributes[:body] = body
       end
     end
 
-    let(:request) { MAuth::Request.new(attributes_for_signing) }
+    describe 'binary body' do
+      let(:body) { File.binread('spec/fixtures/blank.jpeg') }
 
-    it 'returns accurate v1 signature' do
-      signature_v1 = client.signature_v1(request.string_to_sign_v1({}))
-      expect(signature_v1).to eq(testing_info[:signatures][:v1])
+      it 'returns accurate v1 signature' do
+        signature_v1 = client.signature_v1(request.string_to_sign_v1({}))
+        expect(signature_v1).to eq(testing_info[:signatures][:v1_binary])
+      end
+
+      it 'returns accurate v2 signature' do
+        signature_v2 = client.signature_v2(request.string_to_sign_v2({}))
+        expect(signature_v2).to eq(testing_info[:signatures][:v2_binary])
+      end
     end
 
-    it 'returns accurate v2 signature' do
-      signature_v2 = client.signature_v2(request.string_to_sign_v2({}))
-      expect(signature_v2).to eq(testing_info[:signatures][:v2])
+    describe 'empty body' do
+      let(:body) { '' }
+
+      it 'returns accurate v1 signature' do
+        signature_v1 = client.signature_v1(request.string_to_sign_v1({}))
+        expect(signature_v1).to eq(testing_info[:signatures][:v1_empty])
+      end
+
+      it 'returns accurate v2 signature' do
+        signature_v2 = client.signature_v2(request.string_to_sign_v2({}))
+        expect(signature_v2).to eq(testing_info[:signatures][:v2_empty])
+      end
     end
   end
 end

--- a/spec/fixtures/mauth_signature_testing.json
+++ b/spec/fixtures/mauth_signature_testing.json
@@ -1,0 +1,16 @@
+{
+  "description": "Cross platform testing for mAuth signatures",
+  "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAs3zgudWufUW/UFoQtxfBePRDqc63RdpvuBILKHNFAYpxxuSR\nMzQUKSrsvXpWf983/kTtvXBrj4Hm6qWC9fqGKh/qDTnjamXUzxg6utFbcrOrc4hs\nfvfRjEaymclTPLXRa9+iD3vTzDBqS85eDFDm5hTpPwc3C/7+iw0cfWqwP7jJsn5O\nvul50UOuR+czeBWuQXZPh21nUpEI7ZW8U3W2lmO2DrSez2FVtW3Oiek/AQz+uOtl\nNSPoJcH06O2dlh7AAF8c3eFTaYH4gBTFzcBUp3BneZ2cr0e5m5eVRcCOFqDGQF3Y\nJQT2I1EpMecRWo7UW48mF0wzVj/mK1rQUAebgQIDAQABAoIBACAXpf7UTByuCeUO\nFYsHPlqoIikMgwyEYBFjeIdFBQOfg3Ryjdu/5hLuT+IZK7o1aUeXf4KtxS2lpmoy\nKdZdcvu5NRokTZtKleBpjqa0pEtAANnpfKy/FsKkKW8B5lYmlElbdRibpWUPCxJ+\n1aYSGRbuij3wxlDoyQ6Hy55JIzZhQVaKxFr0YQS/v99EArjlhlMJDNqaFEMQ0WUO\n4h7a2ZwAcJ5aDBpCNqFnWg0Vm4u3GM7l50jC0poQGw7UamDL6DWS5UfontSNfBOe\naQO4998dq2FYZGeJiKbZPLzieb1Dk8CcXXgaXO5Lwyy2Rrux+SaSvMOLNki2e593\nlobKOgECgYEA2GQEymGpVY4cqKFHpPIlU/+PhXG9DcZpNzo1oJOxJ5vruoH3UnwV\nmjrP0/NZsjG+loADAhvdlNzBv5pfzmrdUtN/6+HY7zveWfMpdwUSYUaUq+kXDbFH\nNSHCjz+vS6GuOBZ0LvniMR6sAuV25BFP3oCXUxB0+8/z+iyiP4khqNECgYEA1Fea\ntFiD/4kAYivkEX8S1/628o1uqN6rPTB2t0KFaUvH+Mefqf9akZXWqUPbQc2LZEo9\nD6Ez5o51PRBYkHE/C4gfk6ujkwkl8XTgi5owpY73B75ook5mO1MfRIvfvcP1z2Ta\nR2p+uMUDJVO0C4L+RouUWUpkLP8BPg1rUM0sc7ECgYEAkVG6Fd+4RIiHnoeRAajM\ngLijvc5AVDvm9PvWf9wvoJYJnNsjKPXD3Cua3pASsKTPhWq6mnP0PsByLSaTKKCD\nudfnlJW7hg4CqQ2vzwpM6Z7owPpsTPm9BGWDr4fpRTVzNp99rv6JdMtQYTGQwmEN\n7jMVbOckaOeixWOsIlcJj8ECgYEAmYJ3ylePneZai551dBys79AqTLHoxVas70Ch\nIp2Ju3TYrccLa6e6vzNXC+mNkkXZtvhgqnL9BXoJ0cqGbG4iiOCxC13zlHHxp1y6\nlNI0xwvTFRsXo/cPu2W9Xh3M8/C+PWAI2cZotIVhX9PifswFrdRsvBymzUzRhh3H\nbpPVxhECgYAFRJ3qF9kj3TIqupZRknwvEVYMMOK4L8v8zaYjM9WQobcPkROmu7nn\nBzqqXY1SzEH4xRed4OqtTPtglA4jRC4Kr0V0H7terM9u3+p1OIWl7/5X79DYfqyW\nugSNZFZUII03sibgNFxMnj+5s6Bj3PvKjmUnd+Hrt4upKaHH0aRBtA==\n-----END RSA PRIVATE KEY-----",
+  "attributes_for_signing": {
+    "app_uuid": "5ff4257e-9c16-11e0-b048-0026bbfffe5e",
+    "time": 1309891855,
+    "verb": "PUT",
+    "request_url": "/v1/pictures",
+    "body": "<Use the binary value of the blank.jpeg file>",
+    "query_string": "key=-_.~!@#$%^*()+{}|:\"'`<>?&∞=v&キ=v&0=v&a=v&a=b&a=c&a=a&k=&k=v"
+  },
+  "signatures": {
+    "v1": "hDKYDRnzPFL2gzsru4zn7c7E7KpEvexeF4F5IR+puDxYXrMmuT2/fETZty5NkGGTZQ1nI6BTYGQGsU/73TkEAm7SvbJZcB2duLSCn8H5D0S1cafory1gnL1TpMPBlY8J/lq/Mht2E17eYw+P87FcpvDShINzy8GxWHqfquBqO8ml4XtirVEtAlI0xlkAsKkVq4nj7rKZUMS85mzogjUAJn3WgpGCNXVU+EK+qElW5QXk3I9uozByZhwBcYt5Cnlg15o99+53wKzMMmdvFmVjA1DeUaSO7LMIuw4ZNLVdDcHJx7ZSpAKZ/EA34u1fYNECFcw5CSKOjdlU7JFr4o8Phw==",
+    "v2": "kXMtivUVa2aciWcHpxWNFtIAKGHkbC2LjvQCYx5llhhiZOfFQOWNyEcy3qdHj03g27FhefGeMNke/4PThXVRD0fg06Kn+wSCZp+ZHTxUp9m1ZDjlAaNGYjS+LMkQs2oxwg/iJFFAAzvjxzZ9jIhinWM6+PXok5NfU2rvbjjaI5WfRZa8wNl0NeOYlBZPICTcARbT1G6Kr3bjkgBTixNY2dSR1s7MmvpPHzfWSAyaYFppWnJwstRAU/JsR/JzcATZNx/CIk8N+46aWN1Na5avQgLFoNJn6eenXW3W51cENQyhtw7jatvrIKnVckAMoOkygfkbHdCixNfV5G0u1LHU3w=="
+  }
+}

--- a/spec/fixtures/mauth_signature_testing.json
+++ b/spec/fixtures/mauth_signature_testing.json
@@ -6,11 +6,13 @@
     "time": 1309891855,
     "verb": "PUT",
     "request_url": "/v1/pictures",
-    "body": "<Use the binary value of the blank.jpeg file>",
-    "query_string": "key=-_.~!@#$%^*()+{}|:\"'`<>?&∞=v&キ=v&0=v&a=v&a=b&a=c&a=a&k=&k=v"
+    "body": "<Use the binary value of the blank.jpeg file for the '~_binary' signatures, and an empty string for the '~_empty' signatures>",
+    "query_string": "key=-_.~ !@#$%^*()+{}|:\"'`<>?&∞=v&キ=v&0=v&a=v&a=b&a=c&a=a&k=&k=v"
   },
   "signatures": {
-    "v1": "hDKYDRnzPFL2gzsru4zn7c7E7KpEvexeF4F5IR+puDxYXrMmuT2/fETZty5NkGGTZQ1nI6BTYGQGsU/73TkEAm7SvbJZcB2duLSCn8H5D0S1cafory1gnL1TpMPBlY8J/lq/Mht2E17eYw+P87FcpvDShINzy8GxWHqfquBqO8ml4XtirVEtAlI0xlkAsKkVq4nj7rKZUMS85mzogjUAJn3WgpGCNXVU+EK+qElW5QXk3I9uozByZhwBcYt5Cnlg15o99+53wKzMMmdvFmVjA1DeUaSO7LMIuw4ZNLVdDcHJx7ZSpAKZ/EA34u1fYNECFcw5CSKOjdlU7JFr4o8Phw==",
-    "v2": "kXMtivUVa2aciWcHpxWNFtIAKGHkbC2LjvQCYx5llhhiZOfFQOWNyEcy3qdHj03g27FhefGeMNke/4PThXVRD0fg06Kn+wSCZp+ZHTxUp9m1ZDjlAaNGYjS+LMkQs2oxwg/iJFFAAzvjxzZ9jIhinWM6+PXok5NfU2rvbjjaI5WfRZa8wNl0NeOYlBZPICTcARbT1G6Kr3bjkgBTixNY2dSR1s7MmvpPHzfWSAyaYFppWnJwstRAU/JsR/JzcATZNx/CIk8N+46aWN1Na5avQgLFoNJn6eenXW3W51cENQyhtw7jatvrIKnVckAMoOkygfkbHdCixNfV5G0u1LHU3w=="
+    "v1_binary": "hDKYDRnzPFL2gzsru4zn7c7E7KpEvexeF4F5IR+puDxYXrMmuT2/fETZty5NkGGTZQ1nI6BTYGQGsU/73TkEAm7SvbJZcB2duLSCn8H5D0S1cafory1gnL1TpMPBlY8J/lq/Mht2E17eYw+P87FcpvDShINzy8GxWHqfquBqO8ml4XtirVEtAlI0xlkAsKkVq4nj7rKZUMS85mzogjUAJn3WgpGCNXVU+EK+qElW5QXk3I9uozByZhwBcYt5Cnlg15o99+53wKzMMmdvFmVjA1DeUaSO7LMIuw4ZNLVdDcHJx7ZSpAKZ/EA34u1fYNECFcw5CSKOjdlU7JFr4o8Phw==",
+    "v2_binary": "GpZIRB8RIxlfsjcROBElMEwa0r7jr632GkBe+R8lOv72vVV7bFMbJwQUHYm6vL/NKC7g4lJwvWcF60lllIUGwv/KWUOQwerqo5yCNoNumxjgDKjq7ILl8iFxsrV9LdvxwGyEBEwAPKzoTmW9xradxmjn4ZZVMnQKEMns6iViBkwaAW2alp4ZtVfJIZHRRyiuFnITWH1PniyG0kI4Li16kY25VfmzfNkdAi0Cnl27Cy1+DtAl1zVnz6ObMAdtmsEtplvlqsRCRsdd37VfuUxUlolNpr5brjzTwXksScUjX80/HMnui5ZlFORGjHebeZG5QVCouZPKBWTWsELGx1iyaw==",
+    "v1_empty": "UxcRuPRLzjO70NUDG/v71vfs8t/8xyaKN7LTgt6IiV+ul4GRpp3b9EzmF8/b7OTlX3Bsxl7o+E1wfuf4AuqQKE5IqZuhNqZ2t2TPIFdeV4VeF4Eh+gWs6de0KERnEWMTH7OjJsSEQ1gdA7tB3wQhhnf7CpJgMc3P1dSONVgq9qIchspw6L4dadN5bzxH99hN1E/0iPd+qGIeczuhtPMuiNaZRjhFjr2ZsIqn0pYqF+u2czKXd76sZGiBYuUpp/5dQvXBK9v2JlXUmiCoa2LcPj55HR0YEqcPE0mV0k9hyJMwJZeeTKBS5g3QDxoPpB61/+sLuyNp2P/cWrvU03P9dQ==",
+    "v2_empty": "jDB6fhwUA11ZSLb2W4ueS4l9hsguqmgcRez58kUo25iuMT5Uj9wWz+coHSpOd39B0cNW5D5UY6nWifw4RJIv/q8MdqS43WVgnCDSrNsSxpQ/ic6U3I3151S69PzSRZ+aR/I5A85Q9FgWB6wDNf4iX/BmZopfd5XjsLEyDymTRYedmB4DmONlTrsjVPs1DS2xY5xQyxIcxEUpVGDfTNroRTu5REBTttWbUB7BRXhKCc2pfRnUYPBo4Fa7nM8lI7J1/jUasMMLelr6hvcc6t21RCHhf4p9VlpokUOdN8slXU/kkC+OMUE04I021AUnZSpdhd/IoVR1JJDancBRzWA2HQ=="
   }
 }


### PR DESCRIPTION
Related to #35, this PR is to add the cross-platform signature value checks to make sure all mauth-clients implement the MAuth specification correctly.

@mdsol/team-16
@mdsol/architecture-enablement