### PR TITLE
[MCC-575217] Fall back to V1 when V2 authentication fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v5.1.0
+- Fall back to V1 when V2 authentication fails.
+
 ## v5.0.2
 - Fix to not raise FrozenError when string to sign contains frozen value.
 

--- a/lib/mauth/client/authenticator_base.rb
+++ b/lib/mauth/client/authenticator_base.rb
@@ -19,7 +19,7 @@ module MAuth
 
       # raises InauthenticError unless the given object is authentic. Will only
       # authenticate with v2 if the environment variable V2_ONLY_AUTHENTICATE
-      # is set. Otherwise will authenticate with only the highest protocol version present
+      # is set. Otherwise will fallback to v1 when v2 authentication fails
       def authenticate!(object)
         if object.protocol_version == 2
           begin
@@ -32,6 +32,7 @@ module MAuth
 
             log_authentication_request(object)
             authenticate_v1!(object)
+            logger.warn("Completed successful authentication attempt after fallback to v1")
           end
         elsif object.protocol_version == 1
           if v2_only_authenticate?

--- a/lib/mauth/request_and_response.rb
+++ b/lib/mauth/request_and_response.rb
@@ -115,8 +115,8 @@ module MAuth
   # - #x_mws_authentication which returns that header's value
   # - #x_mws_time
   module Signed
-    # mauth_client will authenticate with the highest protocol version present and ignore other
-    # protocol versions.
+    # mauth_client will authenticate with the highest protocol version present and if authentication fails,
+    # will fallback to lower protocol versions (if provided).
     # returns a hash with keys :token, :app_uuid, and :signature parsed from the MCC-Authentication header
     # if it is present and if not then the X-MWS-Authentication header if it is present.
     # Note MWSV2 protocol no longer allows more than one space between the token and app uuid.

--- a/lib/mauth/request_and_response.rb
+++ b/lib/mauth/request_and_response.rb
@@ -121,17 +121,11 @@ module MAuth
     # if it is present and if not then the X-MWS-Authentication header if it is present.
     # Note MWSV2 protocol no longer allows more than one space between the token and app uuid.
     def signature_info
-      @signature_info ||= begin
-        match = if mcc_authentication
-          mcc_authentication.match(
-            /\A(#{MAuth::Client::MWSV2_TOKEN}) ([^:]+):([^:]+)#{MAuth::Client::AUTH_HEADER_DELIMITER}\z/
-          )
-        elsif x_mws_authentication
-          x_mws_authentication.match(/\A([^ ]+) *([^:]+):([^:]+)\z/)
-        end
+      @signature_info ||= build_signature_info(mcc_data || x_mws_data)
+    end
 
-        match ? { token: match[1], app_uuid: match[2], signature: match[3] } : {}
-      end
+    def fall_back_to_mws_signature_info
+      @signature_info = build_signature_info(x_mws_data)
     end
 
     def signature_app_uuid
@@ -152,6 +146,22 @@ module MAuth
       elsif !x_mws_authentication.to_s.strip.empty?
         1
       end
+    end
+
+    private
+
+    def build_signature_info(match_data)
+      match_data ? { token: match_data[1], app_uuid: match_data[2], signature: match_data[3] } : {}
+    end
+
+    def mcc_data
+      mcc_authentication&.match(
+        /\A(#{MAuth::Client::MWSV2_TOKEN}) ([^:]+):([^:]+)#{MAuth::Client::AUTH_HEADER_DELIMITER}\z/
+      )
+    end
+
+    def x_mws_data
+      x_mws_authentication&.match(/\A([^ ]+) *([^:]+):([^:]+)\z/)
     end
   end
 

--- a/lib/mauth/version.rb
+++ b/lib/mauth/version.rb
@@ -1,3 +1,3 @@
 module MAuth
-  VERSION = '5.0.2'.freeze
+  VERSION = '5.1.0'.freeze
 end

--- a/spec/client/local_authenticator_spec.rb
+++ b/spec/client/local_authenticator_spec.rb
@@ -112,6 +112,7 @@ describe MAuth::Client::LocalAuthenticator do
       end
       let(:binary_filepath) { 'spec/fixtures/blank.jpeg' }
       let(:binary_file_body) { File.binread(binary_filepath) }
+      let(:v2_only_authenticate) { true }
 
       it 'considers an authentically-signed request to be authentic' do
         signed_request = client.signed(request)

--- a/spec/client/remote_authenticator_spec.rb
+++ b/spec/client/remote_authenticator_spec.rb
@@ -14,6 +14,7 @@ describe MAuth::Client::RemoteRequestAuthenticator do
       MAuth::Client.new(
         mauth_baseurl: 'http://whatever',
         mauth_api_version: 'v1',
+        app_uuid: 'authenticator',
         v2_only_authenticate: v2_only_authenticate
       )
     end

--- a/spec/support/shared_examples/authenticator_base.rb
+++ b/spec/support/shared_examples/authenticator_base.rb
@@ -61,6 +61,9 @@ shared_examples MAuth::Client::AuthenticatorBase do
           'Mauth-client attempting to authenticate request from app with mauth app uuid ' \
           'signer to app with mauth app uuid authenticator using version MWS.'
         )
+        expect(authenticating_mc.logger).to receive(:warn).with(
+          'Completed successful authentication attempt after fallback to v1'
+        )
 
         expect { authenticating_mc.authenticate!(signed_request) }.not_to raise_error
       end
@@ -73,6 +76,9 @@ shared_examples MAuth::Client::AuthenticatorBase do
           expect(authenticating_mc.logger).to receive(:info).with(
             'Mauth-client attempting to authenticate request from app with mauth app uuid ' \
             'signer to app with mauth app uuid authenticator using version MWS.'
+          )
+          expect(authenticating_mc.logger).to receive(:warn).with(
+            'Completed successful authentication attempt after fallback to v1'
           )
 
           expect { authenticating_mc.authenticate!(signed_request) }.not_to raise_error


### PR DESCRIPTION
Updated the authenticator to fall back to V1 when V2 authentication fails, to migrate smoothly when resolving encoded query parameters in V2

~~Will add MCC later 😅~~ 

@mdsol/team-16 @mdsol/team-51 @mdsol/team-10 @mdsol/architecture-enablement