### PR TITLE
Fix description of the V1 response signing string

### DIFF
--- a/lib/mauth/request_and_response.rb
+++ b/lib/mauth/request_and_response.rb
@@ -25,7 +25,7 @@ module MAuth
     # for responses:
     #   string_to_sign =
     #     status_code_string + <LF> +
-    #     response_body_digest + <LF> +
+    #     response_body + <LF> +
     #     app_uuid + <LF> +
     #     current_seconds_since_epoch
     def string_to_sign_v1(more_attributes)


### PR DESCRIPTION
While attempting to write a new V1 response authenticator from scratch, I discovered that the description in the comments of how the string_to_sign is formed is incorrect. The Ruby code for what actually happens is difficult to follow, but experimentation proves that the signing string is composed of the full response body without any transformations. [See related PR](https://github.com/mdsol/mauth-client-rust/pull/5)

@mdsol/team-16 