### PR TITLE
Replace URI.escape with CGI.escape in SecurityTokenCacher to suppress "URI.escape is obsolete" warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v6.1.1
+* Replace `URI.escape` with `CGI.escape` in SecurityTokenCacher to suppress "URI.escape is obsolete" warning.
+
 ## v6.1.0
 * Allow Faraday 1.x.
 

--- a/lib/mauth/client/security_token_cacher.rb
+++ b/lib/mauth/client/security_token_cacher.rb
@@ -23,8 +23,7 @@ module MAuth
           if !@cache[app_uuid] || @cache[app_uuid].expired?
             # url-encode the app_uuid to prevent trickery like escaping upward with ../../ in a malicious
             # app_uuid - probably not exploitable, but this is the right way to do it anyway.
-            # use UNRESERVED instead of UNSAFE (the default) as UNSAFE doesn't include /
-            url_encoded_app_uuid = URI.escape(app_uuid, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
+            url_encoded_app_uuid = CGI.escape(app_uuid)
             begin
               response = signed_mauth_connection.get("/mauth/#{@mauth_client.mauth_api_version}/security_tokens/#{url_encoded_app_uuid}.json")
             rescue ::Faraday::ConnectionFailed, ::Faraday::TimeoutError => e

--- a/lib/mauth/version.rb
+++ b/lib/mauth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MAuth
-  VERSION = '6.1.0'
+  VERSION = '6.1.1'
 end

--- a/spec/client/security_token_cacher_spec.rb
+++ b/spec/client/security_token_cacher_spec.rb
@@ -43,7 +43,7 @@ describe MAuth::Client::LocalAuthenticator::SecurityTokenCacher do
 
       it 'escapes app_uuid' do
         expect_any_instance_of(Faraday::Connection)
-          .to receive(:get).with("/mauth/v1/security_tokens/!'()*%2B%2C%2F%3A%3B%3D%3F%40%5B%5D.json")
+          .to receive(:get).with("/mauth/v1/security_tokens/%21%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D.json")
           .and_return(response)
 
         subject.get(service_app_uuid)

--- a/spec/client/security_token_cacher_spec.rb
+++ b/spec/client/security_token_cacher_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+require 'faraday'
+require 'mauth/client'
+
+describe MAuth::Client::LocalAuthenticator::SecurityTokenCacher do
+  subject { described_class.new(client) }
+  let(:client) do
+    MAuth::Client.new(
+      mauth_baseurl: 'http://whatever',
+      mauth_api_version: 'v1',
+      private_key: OpenSSL::PKey::RSA.generate(2048),
+      app_uuid: 'authenticator'
+    )
+  end
+
+  describe '#get' do
+    let(:service_app_uuid) { "077dcb2b-f476-4069-adf4-f75c15018d65" }
+    let(:signing_key) { OpenSSL::PKey::RSA.generate(2048) }
+    let(:response) { double(status: status, body: response_body)}
+    let(:status) { 200 }
+    let(:response_body) { JSON.generate({ 'security_token' => { 'public_key_str' => signing_key.public_key.to_s } }) }
+
+    before do
+      allow_any_instance_of(Faraday::Connection)
+        .to receive(:get).with("/mauth/v1/security_tokens/#{service_app_uuid}.json")
+        .and_return(response)
+    end
+
+    shared_examples_for 'Faraday errors' do |faraday_error|
+      before do
+        allow_any_instance_of(Faraday::Connection).to receive(:get).and_raise(faraday_error.new(''))
+      end
+
+      it "logs and raises UnableToAuthenticateError" do
+        expect(client.logger).to receive(:error)
+          .with(/Unable to authenticate with MAuth. Exception mAuth service did not respond; received/)
+        expect { subject.get(service_app_uuid) }.to raise_error(MAuth::UnableToAuthenticateError)
+      end
+    end
+
+    context 'malicious app_uuid' do
+      let(:service_app_uuid) { "!#$&'()*+,/:;=?@[]" }
+
+      it 'escapes app_uuid' do
+        expect_any_instance_of(Faraday::Connection)
+          .to receive(:get).with("/mauth/v1/security_tokens/!'()*%2B%2C%2F%3A%3B%3D%3F%40%5B%5D.json")
+          .and_return(response)
+
+        subject.get(service_app_uuid)
+      end
+    end
+
+    context 'when faraday error occurs' do
+      include_examples 'Faraday errors', Faraday::ConnectionFailed
+      include_examples 'Faraday errors', Faraday::TimeoutError
+    end
+
+    context 'when response body is not JSON' do
+      let(:response_body) { "plain text" }
+
+      it "logs and raises UnableToAuthenticateError" do
+        expect(client.logger).to receive(:error)
+          .with(/Unable to authenticate with MAuth. Exception mAuth service responded with unparseable json/)
+        expect { subject.get(service_app_uuid) }.to raise_error(MAuth::UnableToAuthenticateError)
+      end
+    end
+
+    context 'when response status is 404' do
+      let(:status) { 404 }
+
+      it "raises InauthenticError" do
+        expect { subject.get(service_app_uuid) }
+          .to raise_error(
+            MAuth::InauthenticError,
+            "mAuth service responded with 404 looking up public key for #{service_app_uuid}"
+          )
+      end
+    end
+
+    context 'when response status is not 404' do
+      let(:status) { 500 }
+
+      it "raises UnableToAuthenticateError" do
+        expect { subject.get(service_app_uuid) }.to raise_error(MAuth::UnableToAuthenticateError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The main change is in 30eb931.

### Background

When using mauth-client with ruby 2.7, you will see this warning:
> /home/travis/build/mdsol/mauth-client-ruby/lib/mauth/client/security_token_cacher.rb:27: warning: URI.escape is obsolete

https://travis-ci.org/github/mdsol/mauth-client-ruby/jobs/725788004#L322-L350

`URI.escape` is used only [in SecurityTokenCacher](https://github.com/mdsol/mauth-client-ruby/blob/v6.1.0/lib/mauth/client/security_token_cacher.rb#L27) to encode app_uuid when retrieving public keys from mauth:
```ruby
url_encoded_app_uuid = URI.escape(app_uuid, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
```

this is encoding characters not in `URI::PATTERN::UNRESERVED`:
```ruby
URI::PATTERN::UNRESERVED
#=> "\\-_.!~*'()a-zA-Z\\d" 
```

`CGI.escape` is encoding a little more characters but it should not affect to the characters used for app_uuids:
```ruby
def CGI::escape(string)
    string.gsub(/([^ a-zA-Z0-9_.-]+)/) do
      '%' + $1.unpack('H2' * $1.bytesize).join('%').upcase
    end.tr(' ', '+')
  end
```

@mdsol/team-16 @mdsol/architecture-enablement @jcarres-mdsol 