### PR TITLE
Update MAuth client implementations doc

### DIFF
--- a/doc/implementations.md
+++ b/doc/implementations.md
@@ -4,8 +4,7 @@
 - Clojure: [clojure-mauth-client](https://github.com/mdsol/clojure-mauth-client)
 - Go: [go-mauth-client](https://github.com/mdsol/go-mauth-client)
 - Java: [mauth-jvm-clients](https://github.com/mdsol/mauth-jvm-clients)
-- Python:
-  - [requests-mauth](https://github.com/mdsol/requests-mauth)
-  - [flask-mauth](https://github.com/mdsol/flask-mauth)
+- Python: [mauth-client-python](https://github.com/mdsol/mauth-client-python)
 - R: [RMauthClient](https://github.com/mdsol/RMauthClient)
 - Ruby: [mauth-client-ruby](https://github.com/mdsol/mauth-client-ruby)
+- Rust: [mauth-client-rust](https://github.com/mdsol/mauth-client-rust)


### PR DESCRIPTION
Both the python and rust clients are public now.

@mdsol/team-16 @mdsol/architecture-enablement @jcarres-mdsol