### PR TITLE
use Faraday HTTP Cache to honor server cache control headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v6.2.0
+* Drop legacy security token expiry in favor of honoring server cache headers via Faraday HTTP Cache Middleware.
+
 ## v6.1.1
 * Replace `URI.escape` with `CGI.escape` in SecurityTokenCacher to suppress "URI.escape is obsolete" warning.
 

--- a/lib/mauth/client/security_token_cacher.rb
+++ b/lib/mauth/client/security_token_cacher.rb
@@ -1,3 +1,6 @@
+require 'faraday-http-cache'
+require 'oj'
+
 module MAuth
   class Client
     module LocalAuthenticator
@@ -25,15 +28,8 @@ module MAuth
               raise UnableToAuthenticateError, msg
             end
             if response.status == 200
-              begin
-                security_token = JSON.parse(response.body)
-              rescue JSON::ParserError => e
-                msg =  "mAuth service responded with unparseable json: #{response.body}\n#{e.class}: #{e.message}"
-                @mauth_client.logger.error("Unable to authenticate with MAuth. Exception #{msg}")
-                raise UnableToAuthenticateError, msg
-              end
               @cache_write_lock.synchronize do
-                @cache[app_uuid] = security_token
+                @cache[app_uuid] = security_token_from(response.body)
               end
             elsif response.status == 404
               # signing with a key mAuth doesn't know about is considered inauthentic
@@ -42,10 +38,18 @@ module MAuth
               @mauth_client.send(:mauth_service_response_error, response)
             end
           end
-          @cache[app_uuid].security_token
+          @cache[app_uuid]
         end
 
         private
+
+        def security_token_from(response_body)
+          JSON.parse response_body
+        rescue JSON::ParserError => e
+          msg =  "mAuth service responded with unparseable json: #{response_body}\n#{e.class}: #{e.message}"
+          @mauth_client.logger.error("Unable to authenticate with MAuth. Exception #{msg}")
+          raise UnableToAuthenticateError, msg
+        end
 
         def signed_mauth_connection
           require 'faraday'
@@ -54,7 +58,7 @@ module MAuth
           @signed_mauth_connection ||= ::Faraday.new(@mauth_client.mauth_baseurl, @mauth_client.faraday_options) do |builder|
             builder.use MAuth::Faraday::MAuthClientUserAgent
             builder.use MAuth::Faraday::RequestSigner, 'mauth_client' => @mauth_client
-            builder.use Faraday::HttpCache, store: Rails.cache, serializer: Oj, logger: Rails.logger
+            builder.use :http_cache, serializer: Oj, logger: MAuth::Client.new.logger, shared_cache: false
             builder.adapter ::Faraday.default_adapter
           end
         end

--- a/lib/mauth/version.rb
+++ b/lib/mauth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MAuth
-  VERSION = '6.1.1'
+  VERSION = '6.2.0'
 end

--- a/mauth-client.gemspec
+++ b/mauth-client.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '>= 0.9', '< 2.0'
   spec.add_dependency 'faraday_middleware', '>= 0.9', '< 2.0'
   spec.add_dependency 'faraday-http-cache', '>= 2.0', '< 3.0'
+  spec.add_dependency 'oj', '~> 3.0'
   spec.add_dependency 'term-ansicolor', '~> 1.0'
   spec.add_dependency 'coderay', '~> 1.0'
   spec.add_dependency 'rack'

--- a/mauth-client.gemspec
+++ b/mauth-client.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday', '>= 0.9', '< 2.0'
   spec.add_dependency 'faraday_middleware', '>= 0.9', '< 2.0'
+  spec.add_dependency 'faraday-http-cache', '>= 2.0', '< 3.0'
   spec.add_dependency 'term-ansicolor', '~> 1.0'
   spec.add_dependency 'coderay', '~> 1.0'
   spec.add_dependency 'rack'


### PR DESCRIPTION
instead of legacy 60s expiry.

- this will allow to leverage existing caching library.
- configure the expiry server side.
- get rid of legacy custom code.