### PR TITLE
Fix SecurityTokenCacher to not cache tokens forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v6.2.1
+* Fix SecurityTokenCacher to not cache tokens forever.
+
 ## v6.2.0
 * Drop legacy security token expiry in favor of honoring server cache headers via Faraday HTTP Cache Middleware.
 

--- a/lib/mauth/client/security_token_cacher.rb
+++ b/lib/mauth/client/security_token_cacher.rb
@@ -1,5 +1,4 @@
 require 'faraday-http-cache'
-require 'oj'
 
 module MAuth
   class Client
@@ -9,36 +8,31 @@ module MAuth
         def initialize(mauth_client)
           @mauth_client = mauth_client
           # TODO: should this be UnableToSignError?
-          @mauth_client.assert_private_key(UnableToAuthenticateError.new("Cannot fetch public keys from mAuth service without a private key!"))
-          @cache = {}
-          require 'thread'
-          @cache_write_lock = Mutex.new
+          @mauth_client.assert_private_key(
+            UnableToAuthenticateError.new("Cannot fetch public keys from mAuth service without a private key!")
+          )
         end
 
         def get(app_uuid)
-          if !@cache[app_uuid]
-            # url-encode the app_uuid to prevent trickery like escaping upward with ../../ in a malicious
-            # app_uuid - probably not exploitable, but this is the right way to do it anyway.
-            url_encoded_app_uuid = CGI.escape(app_uuid)
-            begin
-              response = signed_mauth_connection.get("/mauth/#{@mauth_client.mauth_api_version}/security_tokens/#{url_encoded_app_uuid}.json")
-            rescue ::Faraday::ConnectionFailed, ::Faraday::TimeoutError => e
-              msg = "mAuth service did not respond; received #{e.class}: #{e.message}"
-              @mauth_client.logger.error("Unable to authenticate with MAuth. Exception #{msg}")
-              raise UnableToAuthenticateError, msg
-            end
-            if response.status == 200
-              @cache_write_lock.synchronize do
-                @cache[app_uuid] = security_token_from(response.body)
-              end
-            elsif response.status == 404
-              # signing with a key mAuth doesn't know about is considered inauthentic
-              raise InauthenticError, "mAuth service responded with 404 looking up public key for #{app_uuid}"
-            else
-              @mauth_client.send(:mauth_service_response_error, response)
-            end
+          # url-encode the app_uuid to prevent trickery like escaping upward with ../../ in a malicious
+          # app_uuid - probably not exploitable, but this is the right way to do it anyway.
+          url_encoded_app_uuid = CGI.escape(app_uuid)
+          path = "/mauth/#{@mauth_client.mauth_api_version}/security_tokens/#{url_encoded_app_uuid}.json"
+          response = signed_mauth_connection.get(path)
+
+          case response.status
+          when 200
+            security_token_from(response.body)
+          when 404
+            # signing with a key mAuth doesn't know about is considered inauthentic
+            raise InauthenticError, "mAuth service responded with 404 looking up public key for #{app_uuid}"
+          else
+            @mauth_client.send(:mauth_service_response_error, response)
           end
-          @cache[app_uuid]
+        rescue ::Faraday::ConnectionFailed, ::Faraday::TimeoutError => e
+          msg = "mAuth service did not respond; received #{e.class}: #{e.message}"
+          @mauth_client.logger.error("Unable to authenticate with MAuth. Exception #{msg}")
+          raise UnableToAuthenticateError, msg
         end
 
         private
@@ -54,12 +48,17 @@ module MAuth
         def signed_mauth_connection
           require 'faraday'
           require 'mauth/faraday'
-          @mauth_client.faraday_options[:ssl] = { ca_path: @mauth_client.ssl_certs_path } if @mauth_client.ssl_certs_path
-          @signed_mauth_connection ||= ::Faraday.new(@mauth_client.mauth_baseurl, @mauth_client.faraday_options) do |builder|
-            builder.use MAuth::Faraday::MAuthClientUserAgent
-            builder.use MAuth::Faraday::RequestSigner, 'mauth_client' => @mauth_client
-            builder.use :http_cache, serializer: Oj, logger: MAuth::Client.new.logger, shared_cache: false
-            builder.adapter ::Faraday.default_adapter
+          @signed_mauth_connection ||= begin
+            if @mauth_client.ssl_certs_path
+              @mauth_client.faraday_options[:ssl] = { ca_path: @mauth_client.ssl_certs_path }
+            end
+
+            ::Faraday.new(@mauth_client.mauth_baseurl, @mauth_client.faraday_options) do |builder|
+              builder.use MAuth::Faraday::MAuthClientUserAgent
+              builder.use MAuth::Faraday::RequestSigner, 'mauth_client' => @mauth_client
+              builder.use :http_cache, logger: MAuth::Client.new.logger, shared_cache: false
+              builder.adapter ::Faraday.default_adapter
+            end
           end
         end
       end

--- a/lib/mauth/client/security_token_cacher.rb
+++ b/lib/mauth/client/security_token_cacher.rb
@@ -1,4 +1,5 @@
 require 'faraday-http-cache'
+require 'mauth/faraday'
 
 module MAuth
   class Client
@@ -46,8 +47,6 @@ module MAuth
         end
 
         def signed_mauth_connection
-          require 'faraday'
-          require 'mauth/faraday'
           @signed_mauth_connection ||= begin
             if @mauth_client.ssl_certs_path
               @mauth_client.faraday_options[:ssl] = { ca_path: @mauth_client.ssl_certs_path }

--- a/lib/mauth/version.rb
+++ b/lib/mauth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MAuth
-  VERSION = '6.2.0'
+  VERSION = '6.2.1'
 end

--- a/mauth-client.gemspec
+++ b/mauth-client.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '>= 0.9', '< 2.0'
   spec.add_dependency 'faraday_middleware', '>= 0.9', '< 2.0'
   spec.add_dependency 'faraday-http-cache', '>= 2.0', '< 3.0'
-  spec.add_dependency 'oj', '~> 3.0'
   spec.add_dependency 'term-ansicolor', '~> 1.0'
   spec.add_dependency 'coderay', '~> 1.0'
   spec.add_dependency 'rack'
@@ -37,4 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.16'
   spec.add_development_dependency 'timecop', '~> 0.9'
   spec.add_development_dependency 'benchmark-ips', '~> 2.7'
+  spec.add_development_dependency 'webmock', '~> 3.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 require 'timecop'
 require 'json'
 require 'rack/mock'
+require 'byebug'
+require 'webmock/rspec'
 
 require 'simplecov'
 SimpleCov.start


### PR DESCRIPTION
Dropped the internal caching logic (https://github.com/mdsol/mauth-client-ruby/pull/50#discussion_r647050094) to not cache tokens forever.
Added specs to test caching in SecurityTokenCacher.

@mdsol/enablement-ruby 