### PR TITLE
Fix MAuth::Rack::Response to not raise FrozenError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v6.4.1
+- Fix MAuth::Rack::Response to not raise FrozenError.
+
 ## v6.4.0
 - Support Ruby 3.1.
 - Drop support for Ruby < 2.6.0.

--- a/lib/mauth/rack.rb
+++ b/lib/mauth/rack.rb
@@ -170,7 +170,7 @@ module MAuth
 
       def attributes_for_signing
         @attributes_for_signing ||= begin
-          body = ''
+          body = +''
           # NOTE: rack only requires #each be defined on the body, so not using map or inject
           @body.each do |part|
             body << part

--- a/lib/mauth/version.rb
+++ b/lib/mauth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MAuth
-  VERSION = '6.4.0'
+  VERSION = '6.4.1'
 end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -207,6 +207,31 @@ describe MAuth::Rack do
       end
     end
   end
+
+  describe MAuth::Rack::Response do
+    let(:status) { 200 }
+    let(:headers) { {} }
+    let(:body) { %w[hello world] }
+    let(:response) { described_class.new(status, headers, body) }
+
+    describe '#status_headers_body' do
+      it 'returns status, headers and body' do
+        expect(response.status_headers_body).to eq([status, headers, body])
+      end
+    end
+
+    describe '#attributes_for_signing' do
+      it 'returns attributes_for_signing' do
+        expect(response.attributes_for_signing).to eq(status_code: 200, body: 'helloworld')
+      end
+    end
+
+    describe '#merge_headers' do
+      it 'merges headers' do
+        expect(response.merge_headers('foo' => 'bar').status_headers_body).to eq([status, { 'foo' => 'bar' }, body])
+      end
+    end
+  end
 end
 
 describe MAuth::Faraday do


### PR DESCRIPTION
All in the title. Added specs also.

@mdsol/enablement-ruby 